### PR TITLE
Add customizable PDF title. Implemented for all PDF versions.

### DIFF
--- a/lib/App/Music/ChordPro/Config.pm
+++ b/lib/App/Music/ChordPro/Config.pm
@@ -155,7 +155,7 @@ This is the current built-in configuration file, showing all settings.
       "pdf" : {
         // Define the title of the PDF. Fallback is the first title of the
         // first song.
-        "title" : "",
+        "title" : null,
   
   	// Papersize, 'a4' or [ 595, 842 ] etc.
   	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/Config.pm
+++ b/lib/App/Music/ChordPro/Config.pm
@@ -153,6 +153,9 @@ This is the current built-in configuration file, showing all settings.
       // Layout definitions for PDF output.
   
       "pdf" : {
+        // Define the title of the PDF. Fallback is the first title of the
+        // first song.
+        "title" : "",
   
   	// Papersize, 'a4' or [ 595, 842 ] etc.
   	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
@@ -36,7 +36,8 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new($ps);
-    $pr->info( Title => $sb->{songs}->[0]->{meta}->{title}->[0],
+    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    $pr->info( Title => $title,
 	       Creator =>
 	       $regtest
 	       ? "ChordPro [$options->{_name} (regression testing)]"

--- a/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
@@ -36,6 +36,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new($ps);
+    my $title = $ps->{title} // $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
@@ -36,7 +36,6 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new($ps);
-    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
@@ -37,6 +37,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdfapi );
+    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
@@ -37,7 +37,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdfapi );
-    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    my $title = $ps->{title} // $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
@@ -37,7 +37,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdfapi );
-    $pr->info( Title => $sb->{songs}->[0]->{meta}->{title}->[0],
+    $pr->info( Title => $title,
 	       Creator =>
 	       $regtest
 	       ? "ChordPro [$options->{_name} (regression testing)]"

--- a/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
@@ -28,7 +28,8 @@ sub generate_songbook {
     my $ps = $::config->{pdf};
     my $pdffile = $options->{output} || "__new__.pdf";
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdffile );
-    $pr->info( Title => $sb->{songs}->[0]->{meta}->{title}->[0],
+    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    $pr->info( Title => $title,
 	       Creator =>
 	       $regtest
 	       ? "ChordPro [$options->{_name} (regression testing)]"

--- a/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
@@ -28,7 +28,7 @@ sub generate_songbook {
     my $ps = $::config->{pdf};
     my $pdffile = $options->{output} || "__new__.pdf";
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdffile );
-    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    my $title = $ps->{title} // $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/res/config/chordpro.json
+++ b/lib/App/Music/ChordPro/res/config/chordpro.json
@@ -128,6 +128,9 @@
     // Layout definitions for PDF output.
 
     "pdf" : {
+      // Define the title of the PDF. Fallback is the first title of the
+      // first song.
+      "title" : "",
 
 	// Papersize, 'a4' or [ 595, 842 ] etc.
 	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/res/config/chordpro.json
+++ b/lib/App/Music/ChordPro/res/config/chordpro.json
@@ -130,7 +130,7 @@
     "pdf" : {
       // Define the title of the PDF. Fallback is the first title of the
       // first song.
-      "title" : "",
+      "title" : null,
 
 	// Papersize, 'a4' or [ 595, 842 ] etc.
 	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/res/pod/Config.pod
+++ b/lib/App/Music/ChordPro/res/pod/Config.pod
@@ -142,9 +142,6 @@ This is the current built-in configuration file, showing all settings.
       // Layout definitions for PDF output.
   
       "pdf" : {
-        // Define the title of the PDF. Fallback is the first title of the
-        // first song.
-        "title" : "",
   
   	// Papersize, 'a4' or [ 595, 842 ] etc.
   	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/res/pod/Config.pod
+++ b/lib/App/Music/ChordPro/res/pod/Config.pod
@@ -142,6 +142,9 @@ This is the current built-in configuration file, showing all settings.
       // Layout definitions for PDF output.
   
       "pdf" : {
+        // Define the title of the PDF. Fallback is the first title of the
+        // first song.
+        "title" : "",
   
   	// Papersize, 'a4' or [ 595, 842 ] etc.
   	"papersize" : "a4",


### PR DESCRIPTION
I add customizable PDF titles with the config setting "pdf.title".
If the value is present it is used as the title for the PDF (the thing shown in the window-title of the PDF reader). If not, it falls back to the old behaviour of showing the first title of the first song, which is good for single-song conversions.