### PR TITLE
Improve heuristic for chord-line detection in a2crd

### DIFF
--- a/lib/App/Music/ChordPro/A2Crd.pm
+++ b/lib/App/Music/ChordPro/A2Crd.pm
@@ -7,6 +7,7 @@ package App::Music::ChordPro::A2Crd;
 use App::Packager;
 
 use App::Music::ChordPro::Version;
+use App::Music::ChordPro::Chords;
 
 our $VERSION = $App::Music::ChordPro::Version::VERSION;
 
@@ -129,9 +130,21 @@ sub classify {
     return '{' if $line =~ /^\{.+/;	# directive
 
     # Lyrics or Chords heuristic.
+    my @words = split ( /\s+/, $line );
     my $len = length($line);
     $line =~ s/\s+//g;
-    return ( $len / length($line) - 1 ) < 1 ? 'l' : 'c';
+    my $type = ( $len / length($line) - 1 ) < 1 ? 'l' : 'c';
+    my $p = App::Music::ChordPro::Chords::Parser->default;
+    print ref($p), "\n";
+    if ( $type eq 'l') {
+        foreach (@words) {
+            if (!App::Music::ChordPro::Chords::parse_chord($_)) {
+                return 'l';
+            }
+        }
+        return 'c';
+    }
+    return $type;
 }
 
 # Process the lines via the map.

--- a/lib/App/Music/ChordPro/A2Crd.pm
+++ b/lib/App/Music/ChordPro/A2Crd.pm
@@ -136,9 +136,13 @@ sub classify {
     my $type = ( $len / length($line) - 1 ) < 1 ? 'l' : 'c';
     my $p = App::Music::ChordPro::Chords::Parser->default;
     if ( $type eq 'l') {
+        print ( "LYRICS: $line\n" );
         foreach (@words) {
-            if (!App::Music::ChordPro::Chords::parse_chord($_)) {
-                return 'l';
+            if (length $_ > 0) {
+                if (!App::Music::ChordPro::Chords::parse_chord($_)) {
+                    print("\"$_\" is not a valid chord.\n");
+                    return 'l';
+                }
             }
         }
         return 'c';

--- a/lib/App/Music/ChordPro/A2Crd.pm
+++ b/lib/App/Music/ChordPro/A2Crd.pm
@@ -135,7 +135,6 @@ sub classify {
     $line =~ s/\s+//g;
     my $type = ( $len / length($line) - 1 ) < 1 ? 'l' : 'c';
     my $p = App::Music::ChordPro::Chords::Parser->default;
-    print ref($p), "\n";
     if ( $type eq 'l') {
         foreach (@words) {
             if (!App::Music::ChordPro::Chords::parse_chord($_)) {

--- a/lib/App/Music/ChordPro/A2Crd.pm
+++ b/lib/App/Music/ChordPro/A2Crd.pm
@@ -136,11 +136,9 @@ sub classify {
     my $type = ( $len / length($line) - 1 ) < 1 ? 'l' : 'c';
     my $p = App::Music::ChordPro::Chords::Parser->default;
     if ( $type eq 'l') {
-        print ( "LYRICS: $line\n" );
         foreach (@words) {
             if (length $_ > 0) {
                 if (!App::Music::ChordPro::Chords::parse_chord($_)) {
-                    print("\"$_\" is not a valid chord.\n");
                     return 'l';
                 }
             }

--- a/lib/App/Music/ChordPro/Config.pm
+++ b/lib/App/Music/ChordPro/Config.pm
@@ -153,6 +153,9 @@ This is the current built-in configuration file, showing all settings.
       // Layout definitions for PDF output.
   
       "pdf" : {
+        // Define the title of the PDF. Fallback is the first title of the
+        // first song.
+        "title" : "",
   
   	// Papersize, 'a4' or [ 595, 842 ] etc.
   	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
@@ -36,7 +36,8 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new($ps);
-    $pr->info( Title => $sb->{songs}->[0]->{meta}->{title}->[0],
+    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    $pr->info( Title => $title,
 	       Creator =>
 	       $regtest
 	       ? "ChordPro [$options->{_name} (regression testing)]"

--- a/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFClassic/PDF.pm
@@ -36,7 +36,6 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new($ps);
-    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
@@ -37,6 +37,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdfapi );
+    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
@@ -37,7 +37,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdfapi );
-    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    my $title = $ps->{title} // $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFMarkup/PDF.pm
@@ -37,7 +37,7 @@ sub generate_songbook {
 
     my $ps = $::config->{pdf};
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdfapi );
-    $pr->info( Title => $sb->{songs}->[0]->{meta}->{title}->[0],
+    $pr->info( Title => $title,
 	       Creator =>
 	       $regtest
 	       ? "ChordPro [$options->{_name} (regression testing)]"

--- a/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
@@ -28,7 +28,8 @@ sub generate_songbook {
     my $ps = $::config->{pdf};
     my $pdffile = $options->{output} || "__new__.pdf";
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdffile );
-    $pr->info( Title => $sb->{songs}->[0]->{meta}->{title}->[0],
+    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    $pr->info( Title => $title,
 	       Creator =>
 	       $regtest
 	       ? "ChordPro [$options->{_name} (regression testing)]"

--- a/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDFPango/PDF.pm
@@ -28,7 +28,7 @@ sub generate_songbook {
     my $ps = $::config->{pdf};
     my $pdffile = $options->{output} || "__new__.pdf";
     my $pr = (__PACKAGE__."Writer")->new( $ps, $pdffile );
-    my $title = exists $ps->{title} ? $ps->{title} : $sb->{songs}->[0]->{meta}->{title}->[0];
+    my $title = $ps->{title} // $sb->{songs}->[0]->{meta}->{title}->[0];
     $pr->info( Title => $title,
 	       Creator =>
 	       $regtest

--- a/lib/App/Music/ChordPro/res/config/chordpro.json
+++ b/lib/App/Music/ChordPro/res/config/chordpro.json
@@ -128,6 +128,9 @@
     // Layout definitions for PDF output.
 
     "pdf" : {
+      // Define the title of the PDF. Fallback is the first title of the
+      // first song.
+      "title" : "",
 
 	// Papersize, 'a4' or [ 595, 842 ] etc.
 	"papersize" : "a4",

--- a/lib/App/Music/ChordPro/res/pod/Config.pod
+++ b/lib/App/Music/ChordPro/res/pod/Config.pod
@@ -142,6 +142,9 @@ This is the current built-in configuration file, showing all settings.
       // Layout definitions for PDF output.
   
       "pdf" : {
+        // Define the title of the PDF. Fallback is the first title of the
+        // first song.
+        "title" : "",
   
   	// Papersize, 'a4' or [ 595, 842 ] etc.
   	"papersize" : "a4",


### PR DESCRIPTION
This patch double checks lines which where first detected as lyrics. If they only contain chords and nothing else, they are treated as chord lines.

This will not catch all cases, but at least most of them. Of course there can be false positives, but a lyrics line rarely consists of only "C" or contains "Asus4" or something similar.

It calls App::Music::ChordPro::Chords::parse_chord() to check if something is a valid chord.

It can properly parse the following example:
```
This is a song for testing chord detection with the --a2crd funtion:

A         C           D           E  F
The first line of the song is pretty normal,
G
but as the second line has only one chord it's not detected as such.
         Am
However, if this single chord is not right at the beginning of the line, it works again.
 Cm
A single space is not enough though,
  Dm
there have to be at least two.
Emsus4    Am  C
Fooo      Bar Baz
           C    F
 A  Cm D F Even though this starts like some chords it isn't as there is text afterwards.
```

_Note: This branch also includes the changes regarding pdf-titles which I pushed to my "dev" branch. I will try to separate things better next time._