### PR TITLE
(PDF) Only append empty page to front-matter if it has an even number…

### DIFF
--- a/lib/App/Music/ChordPro/Output/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDF.pm
@@ -140,7 +140,7 @@ sub generate_songbook {
 	    $page++;
 	}
 	$pr->newpage( $ps, 1+$matter->pages ), $page++
-	  if $ps->{'even-odd-pages'} && !($page % 2);
+	  if $ps->{'even-odd-pages'} && ($page % 2);
 	$book_toc_page         += $page - 1;
 	$book_start_page       += $page - 1;
 	$book_back_matter_page += $page - 1;


### PR DESCRIPTION
… of pages, if even-odd-pages config option is set.

The purpose of the "even-odd-pages¨ config option is to insert blank pages where necessary to ensure that songs start on the left side of the printed songbook.
However, the front-matter usually starts on the right, as it is the cover page. So, in contrast to all other elements of the songbook (TOC, the songs), it intentionally needs to be an odd number of pages.

I consider this a bug in the current code and created this pull request which fixes the issue.