### PR TITLE
Add markdown support for output-format of chordpro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 !.vscode/
 !.devcontainer/
 *~
-App/
 \#.*#
 CPAN
 Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,16 @@
 .??*
 !.github/
+!.vscode/
+!.devcontainer/
 *~
+App/
 \#.*#
 CPAN
 Makefile
 blib/
 *.cho
 *.pdf
+test.*
 x.*
 Misc
 Released
@@ -25,3 +29,4 @@ pm_to_blib
 pd_*.json
 files*.lst
 res/pod
+.vscode/perl-lang/**

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,6 +4,7 @@ MANIFEST
 Makefile.PL
 README.md
 README.ABC
+README.LilyPond
 lib/App/Music/ChordPro.pm
 lib/App/Music/ChordPro/A2Crd.pm
 lib/App/Music/ChordPro/Chords.pm

--- a/lib/App/Music/ChordPro.pm
+++ b/lib/App/Music/ChordPro.pm
@@ -124,6 +124,9 @@ sub chordpro {
         elsif ( $of =~ /\.mma?$/i ) {
             $options->{generate} ||= "MMA";
         }
+        elsif ( $of =~ /\.(md|markdown)$/i ) {
+            $options->{generate} ||= "Markdown";
+        }
         elsif ( $of =~ /\.(debug)$/i ) {
             $options->{generate} ||= "Debug";
         }

--- a/lib/App/Music/ChordPro/Output/Markdown.pm
+++ b/lib/App/Music/ChordPro/Output/Markdown.pm
@@ -1,0 +1,342 @@
+#!/usr/bin/perl
+
+package main;
+
+our $options;
+our $config;
+
+package App::Music::ChordPro::Output::Markdown;
+
+use App::Music::ChordPro::Output::Common;
+
+use strict;
+use warnings;
+
+sub generate_songbook {
+    my ( $self, $sb ) = @_;
+    my @book;
+   # push(@book, "[TOC]"); # maybe https://metacpan.org/release/IMAGO/Markdown-TOC-0.01 to create a TOC?
+
+    foreach my $song ( @{$sb->{songs}} ) {
+	if ( @book ) {
+	    push(@book, "") if $options->{'backend-option'}->{tidy};
+	}
+	push(@book, @{generate_song($song)});
+    push(@book, "---\n"); #Horizontal line between each song
+	}
+
+    push( @book, "");
+    \@book;
+}
+
+my $single_space = 0;		# suppress chords line when empty
+my $lyrics_only = 0;		# suppress all chords lines
+my $chords_under = 0;		# chords under lyrics
+my $layout = Text::Layout::Markdown->new;
+my $rechorus;
+
+sub upd_config {
+    $lyrics_only  = $config->{settings}->{'lyrics-only'};
+    $chords_under = $config->{settings}->{'chords-under'};
+    $rechorus  = $config->{text}->{chorus}->{recall};
+}
+
+sub generate_song {
+    my ( $s ) = @_;
+
+    my $tidy      = $options->{'backend-option'}->{tidy};
+    $single_space = $options->{'single-space'};
+    upd_config();
+
+    $s->structurize
+      if ( $options->{'backend-option'}->{structure} // '' ) eq 'structured';
+
+    my @s;
+
+    push(@s, "# " . $s->{title})
+      if defined $s->{title};
+    if ( defined $s->{subtitle} ) {
+	push(@s, map { +"## $_" } @{$s->{subtitle}});
+    }
+
+    push(@s, "") if $tidy;
+
+    my $ctx = "";
+    my @elts = @{$s->{body}};
+	my $init_context = 1;
+    while ( @elts ) {
+	my $elt = shift(@elts);
+
+	if ($ctx = $elt->{context} ){ # same context
+		push(@s, "\n**$ctx**\n") if($init_context eq 1);
+		$init_context = 0;
+	} else {
+		$init_context = 1;
+	}
+
+	if ( $elt->{context} ne $ctx ) {
+	    push(@s, "\n**$ctx**\n") if $ctx;
+	}
+
+	if ( $elt->{type} eq "empty" ) {
+	    push(@s, "***SHOULD NOT HAPPEN***")
+	      if $s->{structure} eq 'structured';
+	    push(@s, "");
+	    next;
+	}
+
+#	 if ( $elt->{type} eq "colb" ) {
+#	     push(@s, "\n\n\n");
+#	     next;
+#	}
+
+	 if ( $elt->{type} eq "newpage" ) {
+	     push(@s, "---"); #HR
+	     next;
+	 }
+
+	if ( $elt->{type} eq "songline" ) {
+	    push(@s, songline( $s, $elt ));
+	    next;
+	}
+
+	if ( $elt->{type} eq "tabline" ) { #needed to be fixed font like code
+	    push(@s, "\t".$elt->{text});
+	    next;
+	}
+
+	if ( $elt->{type} eq "chorus" ) {
+	    push(@s, "") if $tidy;
+	    push(@s, "**chorus**");
+	#	push(@s, " ");
+	    foreach my $e ( @{$elt->{body}} ) {
+		if ( $e->{type} eq "empty" ) {
+		    push(@s, "");
+		    next;
+		}
+		if ( $e->{type} eq "songline" ) {
+		    push(@s, songline( $s, $e ));
+		    next;
+		}
+	    }
+	 #   push(@s, " ");
+	    push(@s, "") if $tidy;
+	    next;
+	}
+
+	if ( $elt->{type} eq "rechorus" ) {
+	    if ( $rechorus->{quote} ) {
+		unshift( @elts, @{ $elt->{chorus} } );
+	    }
+	    elsif ( $rechorus->{type} &&  $rechorus->{tag} ) {
+		push( @s, "{".$rechorus->{type}.": ".$rechorus->{tag}."}" );
+	    }
+	    else {
+		push( @s, "{chorus}" );
+	    }
+	    next;
+	}
+
+	if ( $elt->{type} eq "tab" ) {
+	    push(@s, "") if $tidy;
+	    push(@s, "**Tabulatur**  ");
+	    push(@s, "\t".map { $_->{text} } @{$elt->{body}} ); #maybe this need to go for code markup as well´?
+#	    push(@s, " ");
+	    push(@s, "") if $tidy;
+	    next;
+	}
+
+	if ( $elt->{type} eq "verse" ) {
+	    push(@s, "") if $tidy;
+	    push(@s, "**Verse**  ");
+	    foreach my $e ( @{$elt->{body}} ) {
+		if ( $e->{type} eq "empty" ) {
+		    push(@s, "***SHOULD NOT HAPPEN***")
+		      if $s->{structure} eq 'structured';
+		    next;
+		}
+		if ( $e->{type} eq "songline" ) {
+		    push(@s, songline( $s, $e ));
+		    next;
+		}
+		if ( $e->{type} eq "comment" ) {
+		    push(@s, "> " . $e->{text} . "  ");
+		    next;
+		}
+		if ( $e->{type} eq "comment_italic" ) {
+		    push(@s, "> *" .$e->{text}. "*  ");
+		    next;
+		}
+	    }
+	 #   push(@s, " ");
+	    push(@s, "") if $tidy;
+	    next;
+	}
+
+	if ( $elt->{type} =~ /^comment(?:_italic|_box)?$/ ) {
+	    push(@s, "") if $tidy;
+	    my $text = $elt->{text};
+	    if ( $elt->{chords} ) {
+		$text = "";
+		for ( 0..$#{ $elt->{chords} } ) {
+		    $text .= "[" . $elt->{chords}->[$_] . "]"
+		      if $elt->{chords}->[$_] ne "";
+		    $text .= $elt->{phrases}->[$_];
+		}
+	    }
+	    # $text = fmt_subst( $s, $text );
+		if ($elt->{type} =~ /italic$/) {
+			$text = "*" . $text . "*  ";
+		}
+	    push(@s, "> $text  ");
+	    push(@s, "") if $tidy;
+	    next;
+	}
+
+	if ( $elt->{type} eq "image" ) {
+	   # my @args = ( , ")" );
+#	    while ( my($k,$v) = each( %{ $elt->{opts} } ) ) {
+#		push( @args, "$k=$v" );
+#	    }
+#	    foreach ( @args ) {
+#		next unless /\s/;
+#		$_ = '"' . $_ . '"';
+#	    }
+	    push( @s, "![](".$elt->{uri}.")" );
+	    next;
+	}
+
+	if ( $elt->{type} eq "set" ) {
+	    if ( $elt->{name} eq "lyrics-only" ) {
+		$lyrics_only = $elt->{value}
+		  unless $lyrics_only > 1;
+	    }
+	    # Arbitrary config values.
+	    elsif ( $elt->{name} =~ /^(text\..+)/ ) {
+		my @k = split( /[.]/, $1 );
+		my $cc = {};
+		my $c = \$cc;
+		foreach ( @k ) {
+		    $c = \($$c->{$_});
+		}
+		$$c = $elt->{value};
+		$config->augment($cc);
+		upd_config();
+	    }
+	    next;
+	}
+
+	if ( $elt->{type} eq "control" ) {
+	}
+    }
+    push(@s, " ") if $ctx;
+
+    \@s;
+}
+
+sub md_textline{
+	my ( $songline ) = @_;
+	my $empty = $songline;
+    my $textline = $songline;
+    my $nbsp = "\x{00A0}"; #unicode for nbsp sign
+    if($empty =~ /^\s+/){ # starts with spaces
+	    $empty =~ s/^(\s+).*$/$1/; # not the elegant solution - but working - replace all spaces in the beginning of a line
+        my $replaces = $empty;  #with a nbsp symbol as the intend tend to be intentional
+        $replaces =~ s/\s/$nbsp/g;
+        $textline =~ s/$empty/$replaces/;
+    }
+	$textline = $textline."  "; # append two spaces to force linebreak in Markdown
+	return $textline;
+}
+ 
+
+sub songline {
+	# a bit more comments on what this means - i mean elt? whats that suppose to mean?
+    my ( $song, $elt ) = @_;
+
+    my $t_line = "";
+    my @phrases = map { $layout->set_markup($_); $layout->render }
+      @{ $elt->{phrases} };
+
+    if ( $lyrics_only
+	 or
+	 $single_space && ! ( $elt->{chords} && join( "", @{ $elt->{chords} } ) =~ /\S/ ) # also a bit more comment please...
+       ) {
+	$t_line = join( "", @phrases );
+	return md_textline($t_line);
+    }
+
+    unless ( $elt->{chords} ) { # i guess we have a line with chords now... 
+	return ( md_textline(join( " ", @phrases )) );
+    }
+
+    if ( my $f = $::config->{settings}->{'inline-chords'} ) {
+	$f = '[%s]' unless $f =~ /^[^%]*\%s[^%]*$/;
+	$f .= '%s';
+	foreach ( 0..$#{$elt->{chords}} ) {
+	    $t_line .= sprintf( $f,
+				chord( $song, $elt->{chords}->[$_] ),
+				$phrases[$_] );
+	}
+	return ( md_textline($t_line) );
+    }
+
+    my $c_line = "";
+    foreach ( 0..$#{$elt->{chords}} ) {
+	$c_line .= chord( $song, $elt->{chords}->[$_] ) . " ";
+	$t_line .= $phrases[$_];
+	my $d = length($c_line) - length($t_line);
+	$t_line .= "-" x $d if $d > 0;
+	$c_line .= " " x -$d if $d < 0;
+    } # this looks like setting the chords above the words.
+
+    s/\s+$// for ( $t_line, $c_line );
+
+	# main problem in markdown - a fixed position is only available in "Code escapes" so weather to set
+	# a tab or a double backticks (``)  - i tend to the tab - so all lines with tabs are "together"
+	if ($c_line ne ""){ # Block-lines are not replacing initial spaces - as the are "code"
+		$t_line = "\t".$t_line;
+		$c_line = "\t".$c_line;
+		}
+	else{
+		$t_line = md_textline($t_line);
+	}
+	return $chords_under
+		? ( $t_line, $c_line )
+		: ( $c_line, $t_line )
+}
+
+sub chord {
+    my ( $s, $c ) = @_;
+    return "" unless length($c);
+    my $ci = $s->{chordsinfo}->{$c};
+    return "<<$c>>" unless defined $ci;
+    $layout->set_markup($ci->show);
+    my $t = $layout->render;
+    return $ci->is_annotation ? "*$t" : $t;
+}
+
+package Text::Layout::Markdown;
+
+use parent 'Text::Layout';
+
+# Eliminate warning when HTML backend is loaded together with Text backend.
+no warnings 'redefine';
+
+sub new {
+    my ( $pkg, @data ) = @_;
+    my $self = $pkg->SUPER::new;
+    $self;
+}
+
+sub render {
+    my ( $self ) = @_;
+    my $res = "";
+    foreach my $fragment ( @{ $self->{_content} } ) {
+	next unless length($fragment->{text});
+	$res .= $fragment->{text};
+    }
+    $res;
+}
+
+1;


### PR DESCRIPTION
This Pull-Request enhances the chordpro-tool output formating by the option to export to markdown-Format (.md or .markdown) of songs or Songbooks.

* gitignore is enhances by ignoring .vscode and .devcontainer options (my development-environmet) and all files beginning with test.
* sort of auto-added the Readme.lilly-pond 
* Chordpro.pm enhanced by md format-option
* Markdown.pm - logic to generate markdown exports