### PR TITLE
fix small typo in default config

### DIFF
--- a/lib/App/Music/ChordPro/Config.pm
+++ b/lib/App/Music/ChordPro/Config.pm
@@ -1109,7 +1109,7 @@ sub default_config() {
 	"sorted"   :  false,
     },
 
-    // Diagnostig messages.
+    // Diagnostic messages.
     "diagnostics" : {
 	"format" : "\"%f\", line %n, %m\n\t%l",
     },


### PR DESCRIPTION
I was just perusing the default config to see what options I had in the software and noticed the typo.