### PR TITLE
suppressed-chord-diagrams feature

### DIFF
--- a/lib/App/Music/ChordPro/Config.pm
+++ b/lib/App/Music/ChordPro/Config.pm
@@ -934,6 +934,8 @@ sub default_config() {
       // Suppress chords.
       // Overrides --lyrics-only command line option.
       "lyrics-only" : false,
+	  // Suppresses printing of chord diagrams for certain chords
+	  "suppressed-chord-diagrams" : [""],
       // Memorize chords in sections, to be recalled by [^].
       "memorize" : false,
       // Chords inline.

--- a/lib/App/Music/ChordPro/Output/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDF.pm
@@ -311,7 +311,6 @@ my $source;			# song source
 my $structured = 0;		# structured data
 my $suppress_empty_chordsline = 0;	# suppress chords line when empty
 my $suppress_empty_lyricsline = 0;	# suppress lyrics line when blank
-my @suppressed_chord_diagrams = [ "" ]; #List of chords that should not print a diagram
 my $lyrics_only = 0;		# suppress all chord lines
 my $inlinechords = 0;		# chords inline
 my $inlineannots;		# format for inline annots
@@ -334,7 +333,6 @@ sub generate_song {
 
     $suppress_empty_chordsline = $::config->{settings}->{'suppress-empty-chords'};
     $suppress_empty_lyricsline = $::config->{settings}->{'suppress-empty-lyrics'};
-    @suppressed_chord_diagrams = @{$::config->{settings}->{'suppressed-chord-diagrams'}};
     $inlinechords = $::config->{settings}->{'inline-chords'};
     $inlineannots = $::config->{settings}->{'inline-annotations'};
     $chordsunder  = $::config->{settings}->{'chords-under'};
@@ -604,11 +602,10 @@ sub generate_song {
 	$chords = $s->{chords}->{chords}
 	  if !defined($chords) && $s->{chords};
 	$show //= $dctl->{show};
-	my %supchords = map {$_ => 1} @suppressed_chord_diagrams;
 	if ( $chords ) {
 	    for ( @$chords ) {
-		  my $i = $s->{chordsinfo}->{$_};
-		  push( @chords, $i ) unless $i->is_nc || exists $supchords{$i->name};
+		my $i = $s->{chordsinfo}->{$_};
+		push( @chords, $i ) unless $i->is_nc;
 	    }
 	}
 	return unless @chords;
@@ -643,7 +640,6 @@ sub generate_song {
 			 $s->{settings}->{columns} || $::config->{settings}->{columns} );
 	    $col_adjust->();
 	    my $y = $y;
-
 	    while ( @chords ) {
 
 		for ( 0..$c-1 ) {

--- a/lib/App/Music/ChordPro/Output/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDF.pm
@@ -311,6 +311,7 @@ my $source;			# song source
 my $structured = 0;		# structured data
 my $suppress_empty_chordsline = 0;	# suppress chords line when empty
 my $suppress_empty_lyricsline = 0;	# suppress lyrics line when blank
+my @suppressed_chord_diagrams = [ "" ]; #List of chords that should not print a diagram
 my $lyrics_only = 0;		# suppress all chord lines
 my $inlinechords = 0;		# chords inline
 my $inlineannots;		# format for inline annots
@@ -333,6 +334,7 @@ sub generate_song {
 
     $suppress_empty_chordsline = $::config->{settings}->{'suppress-empty-chords'};
     $suppress_empty_lyricsline = $::config->{settings}->{'suppress-empty-lyrics'};
+    @suppressed_chord_diagrams = @{$::config->{settings}->{'suppressed-chord-diagrams'}};
     $inlinechords = $::config->{settings}->{'inline-chords'};
     $inlineannots = $::config->{settings}->{'inline-annotations'};
     $chordsunder  = $::config->{settings}->{'chords-under'};
@@ -602,10 +604,11 @@ sub generate_song {
 	$chords = $s->{chords}->{chords}
 	  if !defined($chords) && $s->{chords};
 	$show //= $dctl->{show};
+	my %supchords = map {$_ => 1} @suppressed_chord_diagrams;
 	if ( $chords ) {
 	    for ( @$chords ) {
-		my $i = $s->{chordsinfo}->{$_};
-		push( @chords, $i ) unless $i->is_nc;
+		  my $i = $s->{chordsinfo}->{$_};
+		  push( @chords, $i ) unless $i->is_nc || exists $supchords{$i->name};
 	    }
 	}
 	return unless @chords;
@@ -640,6 +643,7 @@ sub generate_song {
 			 $s->{settings}->{columns} || $::config->{settings}->{columns} );
 	    $col_adjust->();
 	    my $y = $y;
+
 	    while ( @chords ) {
 
 		for ( 0..$c-1 ) {

--- a/lib/App/Music/ChordPro/Song.pm
+++ b/lib/App/Music/ChordPro/Song.pm
@@ -538,6 +538,9 @@ sub parse_song {
 	my %h;
 	@used_chords = map { $h{$_}++ ? () : $_ } @used_chords;
 
+	my %suppressed_chord_diagrams = map {$_ => 1} @{$::config->{settings}->{'suppressed-chord-diagrams'}};
+	@used_chords = map {$suppressed_chord_diagrams{$_} ? $_ : ()} @used_chords;
+	
 	if ( $diagrams eq "user" && $self->{define} && @{$self->{define}} ) {
 	    @used_chords =
 	    map { $_->{name} } @{$self->{define}};

--- a/lib/App/Music/ChordPro/Song.pm
+++ b/lib/App/Music/ChordPro/Song.pm
@@ -539,7 +539,7 @@ sub parse_song {
 	@used_chords = map { $h{$_}++ ? () : $_ } @used_chords;
 
 	my %suppressed_chord_diagrams = map {$_ => 1} @{$::config->{settings}->{'suppressed-chord-diagrams'}};
-	@used_chords = map {$suppressed_chord_diagrams{$_} ? $_ : ()} @used_chords;
+	@used_chords = map {$suppressed_chord_diagrams{$_} ? () : $_} @used_chords;
 	
 	if ( $diagrams eq "user" && $self->{define} && @{$self->{define}} ) {
 	    @used_chords =

--- a/lib/App/Music/ChordPro/res/config/chordii.json
+++ b/lib/App/Music/ChordPro/res/config/chordii.json
@@ -9,7 +9,9 @@
       "suppress-empty-chords" : false,
       // Suppress blank lyrics lines.
       "suppress-empty-lyrics" : false,
-    },
+ 	  // Suppresses printing of chord diagrams for certain chords
+	  "suppressed-chord-diagrams" : ["A", "Am", "Bb", "B", "Bm", "C", "D", "D7", "Dm", "Dmin", "E", "Em", "Emin", "F", "Fm", "Fmin",   "F#", "F#m", "F#min", "G", "G7", "Gm", "Gmin" ],
+	  },
 
     // Printing chord diagrams.
     // "auto": automatically add unknown chords as empty diagrams.

--- a/lib/App/Music/ChordPro/res/config/chordpro.prp
+++ b/lib/App/Music/ChordPro/res/config/chordpro.prp
@@ -24,6 +24,8 @@ settings {
   # Suppress chords.
   # Overrides --lyrics-only command line option.
   lyrics-only = false
+  # List of chords that should never print diagrams (aka easy chords in chordii)
+  suppressed-chord-diagrams = [""]
   # Memorize chords in sections, to be recalled by [^].
   memorize = false
   # Chords inline.

--- a/lib/App/Music/ChordPro/res/config/config.schema
+++ b/lib/App/Music/ChordPro/res/config/config.schema
@@ -211,6 +211,18 @@
 		    "default": true
 		},
 
+		"suppressed-chord-diagrams": {
+			"title": "Suppressed Chord Diagrams",
+			"description": "Suppress diagrams for listed chords.",
+			"type": "array",
+			"items": {
+				"type": "string",
+			"title": "String",
+			"headerTemplate": "String {{ i1 }}",
+			"pattern": "^[A-G][b#]?[1-9]$"
+			}
+		},
+
 		"titles": {
 		    "description": "Titles flush.",
 		    "type": "string",


### PR DESCRIPTION
Add feature for suppressing "easy" chords like chordii did.
Default is to suppress none, except when using --config=chordii , then the easy chords that chordii has used will be suppressed.
See issue #242 
Users need to define individual lists in json using settings->suppressed-chord-diagrams
