### PR TITLE
RFC Adding Search to ChordPro docs

### DIFF
--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -38,3 +38,8 @@ markup:
         block: true
     renderer:
       unsafe: true
+
+
+module:
+  imports:
+    path: "github.com/kaushalmodi/hugo-search-fuse-js"

--- a/docs/config/_default/menu.yaml
+++ b/docs/config/_default/menu.yaml
@@ -65,3 +65,8 @@ sidebar:
   parent: supp
   weight: 330
   title: All Pages
+
+- identifier: search
+  parent: supp
+  weight: 330
+  title: Search

--- a/docs/content/search.md
+++ b/docs/content/search.md
@@ -1,0 +1,7 @@
++++
+title = "Search"
+layout = "search"
+outputs = ["html", "json"]
+[sitemap]
+  priority = 0.1
++++

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,0 +1,5 @@
+module chordpro
+
+go 1.18
+
+require github.com/kaushalmodi/hugo-search-fuse-js v0.4.4 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,0 +1,4 @@
+github.com/julmot/mark.js v0.0.0-20210820195258-8b57fccf976b/go.mod h1:aAyDyl2EhNPiZbFqqURsAmxYwwTHslrIxZErXMO3pJQ=
+github.com/kaushalmodi/hugo-search-fuse-js v0.4.4 h1:zEnFYi9DYMoHLsMOf5QqXcQJnfEYGaNanqjnTjlJjto=
+github.com/kaushalmodi/hugo-search-fuse-js v0.4.4/go.mod h1:Wr6gbPat+KW6wReh/hDBykKIWn296FsEkuhojJvHHxw=
+github.com/krisk/Fuse v3.2.1+incompatible/go.mod h1:3moWv8rDjwoKic9nwiPLgZjldkbdTAbtzJHCu/Vsj4A=

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -27,4 +27,7 @@
 
   <!-- Menu Toggle Script -->
   {{ partial "menutoggle.html" . }}
+
+  <!-- Search footer block -->
+  {{- block "footer" . }}{{- end }}
 </body>


### PR DESCRIPTION
This PR adds Search functionality to the ChordPro doc pages using [kaushalmodi/hugo-search-fuse-js](https://github.com/kaushalmodi/hugo-search-fuse-js).

Steps were as per [kaushalmodi/hugo-search-fuse-js#readme](https://github.com/kaushalmodi/hugo-search-fuse-js#readme) apart from a small change from TOML to YAML syntax in step 1.

This address #205