### PR TITLE
Extend grid directive

### DIFF
--- a/lib/App/Music/ChordPro/Output/PDF.pm
+++ b/lib/App/Music/ChordPro/Output/PDF.pm
@@ -360,7 +360,8 @@ sub generate_song {
 	$dd = App::Music::ChordPro::Output::PDF::StringDiagrams->new($ps);
 	$dctl = $ps->{diagrams};
     }
-
+    $dctl->{show}=$s->{settings}->{diagrampos} if (defined $s->{settings}->{diagrampos});
+	
     my $sb = $s->{body};
 
     # set_columns needs these, set provisional values.

--- a/lib/App/Music/ChordPro/Song.pm
+++ b/lib/App/Music/ChordPro/Song.pm
@@ -1270,6 +1270,7 @@ sub directive {
 
     if ( $dir eq "grid" ) {
 	$self->{settings}->{diagrams} = 1;
+	$self->{settings}->{diagrampos} = lc($arg) if ($arg =~ /^(right|bottom|top|below)$/i);
 	return 1;
     }
     if ( $dir eq "no_grid" ) {


### PR DESCRIPTION
Add the ability to overwrite the default grid placing by song.
One potential use case:
While placing the diagrams on "right" makes sense for most songs, it reduces horizontal space for multi-column songs significantly, so users might want to exceptionally place the diagram on the bottom for these songs only.
