### PR TITLE
Chord name "|" no longer causes an error

### DIFF
--- a/lib/App/Music/ChordPro/Chords.pm
+++ b/lib/App/Music/ChordPro/Chords.pm
@@ -355,7 +355,7 @@ sub add_config_chord {
 
     # Handle alternatives.
     my @names;
-    if ( $def->{name} =~ /\|/ ) {
+    if ( $def->{name} ne "|" && $def->{name} =~ /\|/ ) {
 	$def->{name} = [ split( /\|/, $def->{name} ) ];
     }
     if ( UNIVERSAL::isa( $def->{name}, 'ARRAY' ) ) {


### PR DESCRIPTION
Pull Request submission for Issue #279
 
Some ChordPro users, notably Songselect.com use `[|]` in some songs as a way of indicating a number of bars repeats of a pattern. In order to support this, a user of ChordPro can add the following to a config file:

	"chords" : [
		{
			"name"  : "|",
			"copy" : "NC"
		},
    ],

However, currently this results in an error in Chords\Parser.pm:233 where the $chord value is not defined. This is due to Chords.pm trying to split the 'name' value on the '|' character as if it was an alternate chord marking (e.g. [G|Csus4]) and producing two empty strings.

This change changes Chords.pm:334 so that it no longer applies the split on \| if the chord name is exactly '|'.