### PR TITLE
Dev appimage debian

### DIFF
--- a/pp/debian/Makefile
+++ b/pp/debian/Makefile
@@ -39,8 +39,8 @@ ppl :: clean ${TARGET} unpack copy_coredll loaders
 .PHONY :: unpack
 unpack :
 	perl ../pp2ppl.pl --dest=${DEST} ${TARGET} --quiet
-	cp -p "${ROOT}/script/chordpro.pl" "${DEST}/script/chordpro.pl" 
-	cp -p "${ROOT}/lib/ChordPro/Config.pm" "${DEST}/lib/ChordPro/Config.pm" 
+	cp -p "${ROOT}/script/chordpro.pl" "${DEST}/script/chordpro.pl"
+	cp -p "${ROOT}/lib/ChordPro/Config.pm" "${DEST}/lib/ChordPro/Config.pm"
 	cp "${DEST}/res/icons/chordpro.ico" ${DEST}
 	mv "${DEST}/res" "${DEST}/lib/ChordPro/"
 
@@ -73,12 +73,12 @@ _loaders : "${DEST}/chordpro"
 	cp "${DEST}/chordpro" "${DEST}/perl"
 
 "${DEST}/wxchordpro" : ${BASE}/ppl.c
-	${CC} ${CCOPTS} -o "${DEST}/wxchordpro" -L${DEST} ${LDOPTS} \
-	    ${BASE}/ppl.c ${SYSLIB}/libperl.a ${SYSLIB}/libcrypt.a -lm
+	${CC} ${CCOPTS} -o "${DEST}/wxchordpro" -L${DEST} \
+	    ${BASE}/ppl.c ${SYSLIB}/libperl.a ${SYSLIB}/libcrypt.a -lm ${LDOPTS}
 
 "${DEST}/chordpro" : ${BASE}/ppl.c
-	${CC} ${CCOPTS} -o "${DEST}/chordpro" -L${DEST} ${LDOPTS} \
-	    ${BASE}/ppl.c ${SYSLIB}/libperl.a ${SYSLIB}/libcrypt.a -lm
+	${CC} ${CCOPTS} -o "${DEST}/chordpro" -L${DEST} \
+	    ${BASE}/ppl.c ${SYSLIB}/libperl.a ${SYSLIB}/libcrypt.a -lm ${LDOPTS}
 
 clean ::
 	rm -fr build
@@ -88,10 +88,9 @@ APPIMAGETOOL := appimagetool
 
 appimage : ppl _appimage
 
-_appimage : 
-	sed -e "s/TARGET=.*/TARGET=${TARGET}/" ${BASE}/AppRun > ${DEST}/AppRun
+_appimage :
+	cp ${BASE}/AppRun ${DEST}/AppRun
 	chmod 0755 ${DEST}/AppRun
 	cd ${DEST}; ln -f lib/ChordPro/res/linux/chordpro.desktop .
 	cd ${DEST}; ln -f lib/ChordPro/res/icons/chordpro.png .
 	${APPIMAGETOOL} -n ${DEST} ChordPro-${VERSION}.AppImage
-

--- a/pp/debian/wxchordpro.pp
+++ b/pp/debian/wxchordpro.pp
@@ -3,19 +3,23 @@
 @../common/wxchordpro.pp
 
 # Explicitly link the wxGTK3 libraries.
---link=libwx_baseu-3.2.so.0
---link=libwx_baseu_net-3.2.so.0
---link=libwx_baseu_xml-3.2.so.0
---link=libwx_gtk3u_adv-3.2.so.0
---link=libwx_gtk3u_aui-3.2.so.0
---link=libwx_gtk3u_core-3.2.so.0
---link=libwx_gtk3u_html-3.2.so.0
---link=libwx_gtk3u_media-3.2.so.0
---link=libwx_gtk3u_propgrid-3.2.so.0
---link=libwx_gtk3u_ribbon-3.2.so.0
---link=libwx_gtk3u_richtext-3.2.so.0
+--link=libwx_baseu-3.0.so.0
+--link=libwx_baseu_net-3.0.so.0
+--link=libwx_baseu_xml-3.0.so.0
+--link=libwx_gtk3u_adv-3.0.so.0
+--link=libwx_gtk3u_aui-3.0.so.0
+--link=libwx_gtk3u_core-3.0.so.0
+--link=libwx_gtk3u_html-3.0.so.0
+--link=libwx_gtk3u_media-3.0.so.0
+--link=libwx_gtk3u_propgrid-3.0.so.0
+--link=libwx_gtk3u_ribbon-3.0.so.0
+--link=libwx_gtk3u_richtext-3.0.so.0
 
 # And more...
+--link=libdeflate.so.0
+--link=libjbig.so.0
+--link=libjpeg.so.8
 --link=libpng16.so.16
---link=libjpeg.so.62
 --link=libSDL2-2.0.so.0
+--link=libtiff.so.5
+--link=libwebp.so.6

--- a/pp/linux/AppRun
+++ b/pp/linux/AppRun
@@ -3,7 +3,13 @@
 SELF=$(readlink -f "$0")
 HERE=${SELF%/*}
 TARGET=wxchordpro
+export LD_LIBRARY_PATH=$HERE:$LD_LIBRARY_PATH
 export APPIMAGE_PACKAGED=1.00
+
+if [ "$1" = "chordpro" ]; then
+    TARGET=chordpro
+    shift  # remove "chordpro" arg
+fi
 
 if [ ! -z $APPIMAGE ] ; then
   BINARY_NAME=$(basename "$ARGV0")


### PR DESCRIPTION
PR to update pp/debian to create an AppImage that works on Ubuntu 20.04 and later.  

The binary attached below was built on Ubuntu 20.04 and tested on Fedora 39, Ubuntu 23.10, 22.04 and Ubuntu 20.04 and runs successfully on all.

[ChordPro-6.050_021 (20.04).zip](https://github.com/ChordPro/chordpro/files/14829282/ChordPro-6.050_021.20.04.zip)

I also modified the pp/linux/AppRun file to allow calling cli chordpro from the AppImage, e.g.
```
$ ./ChordPro-6.050_021.AppImage chordpro -A

ChordPro: A lyrics and chords formatting program.

ChordPro will read a text file containing the lyrics of one or many
songs plus chord information. ChordPro will then generate a
photo-ready, professional looking, impress-your-friends sheet-music
suitable for printing on your nearest printer.

To learn more about ChordPro, look for the man page or do
"chordpro --help" for the list of options.

For more information, see https://www.chordpro.org .

Run-time information:
  ChordPro core          6.050_021  (Unsupported development snapshot)
  Perl                   v5.34.0    (/tmp/.mount_ChordPLmFBCD/chordpro)
  AppImage Packager      1.00      
  Resource path          ~/.config/chordpro
                         /tmp/.mount_ChordPLmFBCD/lib/ChordPro/res
  ABC support            QuickJS_XS (ABC2SVG version v1.22.14 of 2024-03-03)

Modules and libraries:
  Storable               3.25      
  Object::Pad            0.79      
  Text::Layout           0.035     
  HarfBuzz::Shaper       0.026     
  HarfBuzz library       2.6.4i    
  File::LoadLines        1.046     
  PDF::API2              2.045     
  SVGPDF                 0.086.2   
  Font::TTF              1.06      
  JavaScript::QuickJS    0.19      
```
The packages and toolchain required was:
```
sudo apt install -y wget fuse libwx-perl cpanminus liblocal-lib-perl libgtk-3-dev libperl-dev libdeflate0 libsdl2-2.0-0 patchelf git build-essential libpar-packer-perl
git clone https://github.com/lpinner/chordpro.git
cd chordpro/pp/debian
wget -O appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
chmod u+x appimagetool
export PATH=.:$PATH
cpanm -n -l /tmp/build chordpro HarfBuzz::Shaper
export PERL5LIB=/tmp/build/lib/perl5
make
```
