### PR TITLE
SwiftUI wrapper: smoother browsing of ‘versions’

### DIFF
--- a/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+Coordinator.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+Coordinator.swift
@@ -144,6 +144,8 @@ public extension ChordProEditor {
                 do {
                     try await Task.sleep(nanoseconds: 1_000_000_000)
                     parent.text = textView.string
+                    /// Remove the task so we allow external updates of the text binding again
+                    self.task = nil
                 } catch { }
             }
         }

--- a/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+Settings.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+Settings.swift
@@ -27,6 +27,7 @@ extension ChordProEditor {
         /// The font style of the editor
         public var fontStyle: FontStyle = .monospaced
 
+        /// The calculated font for the editor
         public var font: NSFont {
             return fontStyle.nsFont(size: fontSize)
         }

--- a/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+Wrapper.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+Wrapper.swift
@@ -89,11 +89,7 @@ extension ChordProEditor {
         }()
 
         /// The `NSRulerView`
-        //lazy private var lineNumbers = NSRulerView()
-        lazy var lineNumbers: LineNumbersView = {
-            let lineNumbersView = LineNumbersView()
-            return lineNumbersView
-        }()
+        lazy private var lineNumbers = LineNumbersView()
 
         public override func viewWillDraw() {
             super.viewWillDraw()
@@ -106,7 +102,7 @@ extension ChordProEditor {
             lineNumbers.scrollView = scrollView
             lineNumbers.orientation = .verticalRuler
             lineNumbers.clientView = textView
-            lineNumbers.ruleThickness = 40
+            lineNumbers.ruleThickness = (textView.font?.pointSize ?? 14) * 4
 
             scrollView.verticalRulerView = lineNumbers
 

--- a/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor.swift
@@ -43,6 +43,7 @@ public struct ChordProEditor: NSViewRepresentable {
         wrapper.delegate = context.coordinator
         wrapper.textView.directives = directives
         wrapper.textView.parent = self
+        wrapper.textView.font = settings.font
         wrapper.textView.string = text
         /// Wait for next cycle and set the textview as first responder
         Task { @MainActor in


### PR DESCRIPTION
Set the selected font of the editor before showing the ‘View’ to prevent jumping of text while browsing older versions