### PR TITLE
SwiftUI wrapper: bug fixes

### DIFF
--- a/pp/macosswift/ChordProMac/ChordProMac/AppKitUtils/AppKitUtils+PDFKitRepresentedView.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/AppKitUtils/AppKitUtils+PDFKitRepresentedView.swift
@@ -43,6 +43,8 @@ extension AppKitUtils {
                 }
                 /// Get the optional debug info
                 if let firstPage = pdfView.document?.page(at: 0) {
+                    /// Clear the annotations
+                    annotations = []
                     for annotation in firstPage.annotations {
                         annotations.append((annotation.userName ?? "Error", annotation.contents ?? "Error"))
                     }

--- a/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+highlight.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/ChordProEditor/ChordProEditor+highlight.swift
@@ -28,7 +28,7 @@ extension ChordProEditor {
     /// The regex for directive arguments
     static let directiveArgumentRegex = try! NSRegularExpression(pattern: "(?<=\\:)(.*)(?=\\})")
     /// The regex for comments
-    static let commentsRegex = try! NSRegularExpression(pattern: "#[^\\[\\]\\n]*")
+    static let commentsRegex = try! NSRegularExpression(pattern: "(?<=^|\\n)#[^\\n]*")
     /// The regex for markup
     static let markupRegex = try! NSRegularExpression(pattern: "<\\/?[^>]*>")
     /// The regex for brackets

--- a/pp/macosswift/ChordProMac/ChordProMac/ChordProMacApp.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/ChordProMacApp.swift
@@ -75,6 +75,11 @@ public struct ResetApplicationButtonView: View {
                     in: .userDomainMask
                 ).first {
                     try? manager.removeItem(at: cacheFolderURL)
+                    try? manager.createDirectory(
+                        at: cacheFolderURL,
+                        withIntermediateDirectories: false,
+                        attributes: nil
+                    )
                 }
                 /// Terminate the application
                 NSApp.terminate(nil)

--- a/pp/macosswift/ChordProMac/ChordProMac/Views/PreviewPDFButtonView.swift
+++ b/pp/macosswift/ChordProMac/ChordProMac/Views/PreviewPDFButtonView.swift
@@ -30,7 +30,7 @@ struct PreviewPDFButtonView: View {
                 }
             },
             label: {
-                Label(label, systemImage: sceneState.preview.url == nil ? "eye" : "eye.fill")
+                Label(label, systemImage: sceneState.preview.data == nil ? "eye" : "eye.fill")
             }
         )
         .help("Preview the PDF")


### PR DESCRIPTION
- Recreate the cache directory when resetting the application
- Reset the debug info on PDF refresh
- Show the ‘eye’ icon filled when showing a preview
- Make the regex for comments a bit smarter