### PR TITLE
Fix pod2man warning

### DIFF
--- a/lib/ChordPro.pm
+++ b/lib/ChordPro.pm
@@ -643,8 +643,6 @@ The default configuration is commented to explain its contents.
 Prints the final configuration (after processing all system, user and
 other config files)  to standard output, and exits.
 
-=back
-
 =item B<--convert-config=>I<file>
 
 This option requires a single file name argument.

--- a/lib/ChordPro/res/pod/ChordPro.pod
+++ b/lib/ChordPro/res/pod/ChordPro.pod
@@ -388,8 +388,6 @@ The default configuration is commented to explain its contents.
 Prints the final configuration (after processing all system, user and
 other config files)  to standard output, and exits.
 
-=back
-
 =item B<--convert-config=>I<file>
 
 This option requires a single file name argument.


### PR DESCRIPTION
pod2man complains that there's an =item outside of =over.  That's because there's a superfluous =back.
This change fixes this. 