### PR TITLE
macOS classic: Fix blurred window on retina display

### DIFF
--- a/pp/macos/Info.plist
+++ b/pp/macos/Info.plist
@@ -16,6 +16,8 @@
   <string>6.0</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
   <key>CFBundleSignature</key>
   <string>CHO#</string>
   <key>CFBundleShortVersion</key>


### PR DESCRIPTION
On macs with a retina display; a wxWindow looks blurred unless you set the proper `NSPrincipalClass` in its Info.plist