### PR TITLE
(Wx) New dndhandler for macOS

### DIFF
--- a/pp/macos/Info.plist
+++ b/pp/macos/Info.plist
@@ -1,50 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleName</key>
-  <string>ChordPro</string>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>English</string>
-  <key>CFBundleExecutable</key>
-  <string>dndhandler</string>
-  <key>CFBundleIconFile</key>
-  <string>chordpro.icns</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.chordpro.chordpro</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>NSPrincipalClass</key>
-  <string>NSApplication</string>
-  <key>CFBundleSignature</key>
-  <string>CHO#</string>
-  <key>CFBundleShortVersionString</key>
-  <string>6.07.0</string>
-  <key>CFBundleVersion</key>
-  <string>6.07.0</string>
-  <key>NSHumanReadableCopyright</key>
-  <string>Copyright 2016,2024 Johan Vromans &lt;jvromans@squirrel.nl&gt;</string>
-  <key>CFBundleDocumentTypes</key>
-  <array>
-    <dict>
-      <key>CFBundleTypeExtensions</key>
-      <array>
-	<string>cho</string>
-	<string>chordpro</string>
-	<string>chopro</string>
-	<string>crd</string>
-      </array>
-      <key>CFBundleTypeIconFile</key>
-      <string>chordpro-doc.icns</string>
-      <key>LSIsAppleDefaultForType</key>
-      <string>Yes</string>
-      <key>CFBundleTypeRole</key>
-      <string>Editor</string>
-      <key>CFBundleTypeName</key>
-      <string>ChordPro document</string>
-    </dict>
-  </array>
+	<key>CFBundleName</key>
+	<string>ChordPro</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>dndhandler</string>
+	<key>CFBundleIconFile</key>
+	<string>chordpro.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.chordpro.chordpro</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>CFBundleSignature</key>
+	<string>CHO#</string>
+	<key>CFBundleShortVersionString</key>
+	<string>6.08.0</string>
+	<key>CFBundleVersion</key>
+	<string>6.08.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright 2016,2025 Johan Vromans &lt;jvromans@squirrel.nl&gt;</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>cho</string>
+				<string>chordpro</string>
+				<string>chopro</string>
+				<string>crd</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>chordpro-doc.icns</string>
+			<key>LSIsAppleDefaultForType</key>
+			<string>Yes</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleTypeName</key>
+			<string>ChordPro document</string>
+		</dict>
+	</array>
+	<key>LSUIElement</key>
+	<true/>
 </dict>
 </plist>

--- a/pp/macos/dndhandler.swift
+++ b/pp/macos/dndhandler.swift
@@ -7,40 +7,108 @@
 
 import AppKit
 
-// MARK: Start the application
-
-let app = NSApplication.shared
-let delegate = AppDelegate()
-app.delegate = delegate
-
-_ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
-
-// MARK: The Application Delegate
-
-@available(macOS 10.15, *)
-class AppDelegate: NSObject, NSApplicationDelegate {
-    /// The optional URL to open
-    var open: URL?
-    /// Store the requested file URL to add as agument for **wxchordpro**
-    func application(_ sender: NSApplication, open urls: [URL]) {
-        open = urls.first
-    }
-    /// Set the arguments and create a window with **wxchordpro**
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
-        let path = Bundle.main.executablePath?.replacingOccurrences(of: "dndhandler", with: "wxchordpro")
-        if let path = path {
-            /// We *must* create arguments and the first one is the path to the executable
-            var args: [String] = ["\(path)"]
-            /// Add the optional file URL as second argument
-            if let open = open {
-                args.append("\(open.path)")
+if #available(macOS 10.15, *) {
+    
+    // MARK: Start the application
+    
+    let app = NSApplication.shared
+    let delegate = AppDelegate()
+    app.delegate = delegate
+    
+    _ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
+    
+    // MARK: The Application Delegate
+    
+    class AppDelegate: NSObject, NSApplicationDelegate {
+        
+        /// The optional URLs to open, either dropped or clicked in the Finder
+        var open: [URL]?
+        /// Bool if the **dndhandler** is already running
+        var running: Bool = false
+        /// Current open **wxchordpro** windows
+        var openWindows: [String: Int32] = [:]
+        
+        /// # Protocol functions
+        
+        /// Store the requested file URL to add as argument for **wxchordpro**
+        func application(_ sender: NSApplication, open urls: [URL]) {
+            open = urls
+            /// The dndhandler is already running, open the **wxchordpro** windows
+            if running {
+                createWxChordProProcess()
             }
-            /// Black magic
-            let cargs = args.map { strdup($0) } + [nil]
-            /// Execute the **wxchordpro** program with its arguments
-            execv(path, cargs)
         }
-        /// This should not happen
-        fatalError("exec failed")
+        
+        /// Hide the dock icon of the **dndhandler**
+        func applicationWillFinishLaunching(_ notification: Notification) {
+            NSApp.setActivationPolicy(.prohibited)
+        }
+
+        /// Set the arguments and create a window with **wxchordpro**
+        func applicationDidFinishLaunching(_ aNotification: Notification) {
+            /// Remember that we are launched
+            running = true
+            /// Open at least one window
+            createWxChordProProcess()
+        }
+        /// Bring all **wxchordpro** windows to the foreground
+        func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+            for app in NSWorkspace.shared.runningApplications where app.localizedName == "ChordPro" {
+                if !app.isActive {
+                    app.activate(options: NSApplication.ActivationOptions.activateIgnoringOtherApps)
+                }
+            }
+            return false
+        }
+        
+        /// # Private functions
+        
+        private func createWxChordProProcess() {
+            /// Open **wxchordpro** with the file(s) as argument
+            if let open = open {
+                for file in open {
+                    if let windowID = openWindows[file.path] {
+                        NSLog("Already open: \(file.lastPathComponent)")
+                        for app in NSWorkspace.shared.runningApplications where app.processIdentifier == windowID {
+                            app.activate(options: NSApplication.ActivationOptions.activateIgnoringOtherApps)
+                        }
+                    } else {
+                        NSLog("Opening: \(file.lastPathComponent)")
+                        launchProcess(argument: file.path)
+                    }
+                }
+                /// Clear the list with files to open
+                self.open = nil
+            } else {
+                /// Just open, it is not a DnD
+                NSLog("Opening Main Window")
+                launchProcess(argument: "main")
+            }
+        }
+        
+        private func launchProcess(argument: String) {
+            let path = Bundle.main.executablePath?.replacingOccurrences(of: "dndhandler", with: "wxchordpro")
+            let process = Process()
+            process.launchPath = path ?? ""
+            /// Add the file argument
+            /// - Note: Main means no file argument
+            if argument != "main" {
+                process.arguments = [argument]
+            }
+            process.terminationHandler = { _ in
+                self.openWindows[argument] = nil
+                if self.openWindows.isEmpty {
+                    /// No more open windows
+                    NSLog("All windows closed, terminating")
+                    NSApplication.shared.terminate(nil)
+                }
+            }
+            process.launch()
+            /// Remember the window ID
+            openWindows[argument] = process.processIdentifier
+            /// Make sure the **dndhandler** is still hidden
+            /// - Note: This is needed for macOS Sequoia
+            NSApp.setActivationPolicy(.prohibited)
+        }
     }
 }


### PR DESCRIPTION
Run `dndhandler` as background process and launch a separate `wxchordpro` process for each file that is dragged/dropped or opened by double-click in the Finder.

This will allow multiple *ChordPro* windows to be open at the same time and fixes the issue that the `dndhandler` only worked once at startup.

When drag/drop or clicking a song that is already open, that window will be brought in front instead of opening a new window; standard macOS behaviour.

When the last window is closed, the background process will be terminated; so no hidden processes when no window is open.

Known issues:

- Each window will have its own icon in the Dock
- When starting *ChordPro* or opening a new document in its own window, the dock icon does some strange bouncing (once)

Tested on macOS Ventura and Sequoia