### PR TITLE
(website) Add landing page to Hugo

### DIFF
--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -1,0 +1,108 @@
+body {
+    background: linear-gradient(to bottom, #E5F3FF 0%,#ffffff 20em,#ffffff 100%);
+    background-attachment: fixed;
+}
+
+/* id's */
+
+#wrapper {
+    max-width: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+    padding: 1em;
+}
+#logo {
+    color: #0068d9;
+    font-size: 4em;
+}
+#logo img {
+    width: 1em;
+    height: 1em;
+}
+#logo p {
+    display: inline;
+    vertical-align: text-top;
+}
+#subtitle {
+    color: grey;
+}
+#statement {
+    font-weight: bold;
+    font-size: 1.2em;
+}
+#examples {
+    margin-bottom: 2em;
+}
+#examples p, #examples img {
+    margin: 0.5em;
+}
+#examples img {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+#about {
+    background-color: #143968;
+    color: white;
+    padding: 1em;
+    border-radius: 0.5em;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    margin-bottom: 1em;
+}
+#about h1 {
+    color: white;
+}
+#footer {
+	display: absolute;
+    background-color: #3a3a3a;
+    color: white;
+    border-top: 1px solid black;
+    padding: 0 2em 0 2em;
+}
+#footer p {
+    margin: 0;
+}
+#footer a {
+    color: white;
+    margin-left: 1em;
+    font-size: 1.5em;
+}
+
+/* classes */
+
+.link-button a {
+    background: #ef6c2a;
+    padding: 0.4em;
+    color: white;
+    border-radius: 0.3em;
+}
+.row {
+    display: flex;
+}
+.column {
+    padding: 1em;
+    flex: 50%;
+}
+.left-align {
+    text-align: left;
+}
+.right-align {
+    text-align: right;
+}
+
+/* Definition lists */
+
+dl {
+    margin: 2em;
+    text-align: left;
+}
+
+dt {
+    color: #0068d9;
+    font-size: 1.2em;
+}
+dt span, p span {
+    padding-left: 0.5em;
+}
+dd {
+    padding: 0.5em;
+}

--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -2,7 +2,7 @@
 
 title: ChordPro
 baseURL: https://www.chordpro.org/beta/
-languageCode: en-EN
+languageCode: en-GB
 
 # Build properties.
 
@@ -26,6 +26,10 @@ params:
   keywords: music,chord,chords,chordii,chordpro,typesetting,chopro,cho,crd,guitar,music sheets
 
   stable: https://www.chordpro.org/chordpro/
+  
+  link_github: https://github.com/ChordPro/chordpro
+  link_paypal: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=WDKWDE6R3KR98&lc=GB&item_name=ChordPro&currency_code=EUR&bn=PP-DonationsBF%3Abtn_donate_LG.gif%3ANonHosted
+  link_coffee: https://ko-fi.com/chordpro
 
 # Currently the goldmark parser misinterprets `[%`_name_`%]`.
 #markup:

--- a/docs/content/Landing.md
+++ b/docs/content/Landing.md
@@ -1,0 +1,118 @@
+---
+type: landing
+title: "Welcome to ChordPro!"
+subtitle: A simple text format for the notation of lyrics with chords
+description: The official site for the ChordPro file format and its reference implementation
+footer1: This is the official site for **ChordPro**
+footer2: The reference implementation of the open **ChordPro** format
+---
+
+Here you can find all the information and tools you need to embrace this format to enhance your musical notations. **ChordPro** will help you to let your songs looks great so you just want to play them.
+
+{{< linkbutton >}}
+[Read more]({{< ref "Home" >}})
+{{< /linkbutton >}}
+
+[![Image]({{< asset "images/chordpro-gui-cli.png" >}})]({{< ref "Home" >}})
+
+{{< awesome_icon "fa-book" "Create Songbooks" >}}
+: Turn your **ChordPro** formatted songs into beautiful looking [songbooks]({{< ref "ChordPro-GUI-Songbook" >}}).
+
+{{< awesome_icon "fa-music" "Any Musical Purpose" >}}
+: Although initially intended for guitarists, **ChordPro** can be used for all kinds of musical purposes.
+
+{{< awesome_icon "fa-check-circle-o" "Popular Standard" >}}
+: **ChordPro** became a popular way to write lead sheets and many tools adopted its format.
+
+{{< awesome_icon "fa-file-text-o" "Simple Text Format" >}}
+: **ChordPro** is a simple text file format. Any text editor can be used to create and maintain them.
+
+# ChordPro examples
+
+Here you can see a couple of examples of what <strong>ChordPro</strong> can do for you with its powerful PDF creation:
+
+<div id="examples">
+
+{{< showpages
+"example-armenian"
+"example-background"
+"example-biscuit1"
+"example-mollymalone"
+"example-twelvedays"
+"example-biscuit2"
+>}}
+
+</div>
+
+# A simple format but not *simple*
+
+While *simple* by nature, the reference implementation of **ChordPro** has very powerful features.
+
+{{< awesome_icon "fa-code" "Markup" >}}
+: It is possible to use markup in lyrics and other texts to change the way how these will be displayed.
+
+{{< awesome_icon "fa-exchange" "Custom Tunings and Notes" >}}
+: Not just C F G on a 6-string EADGBE tuned guitar. C D E or Do Re Mi? Nashville or Roman? **ChordPro** supports alternative tunings and note naming systems.
+
+{{< awesome_icon "fa-music" "Integrated ABC" >}}
+: Include fragments of musical scores with the integrated [ABC](https://abcnotation.com") support.
+
+<div id="about">
+
+# About ChordPro
+
+<div class="row">
+
+<div class="column">
+
+In 1992 Martin Leclerc and Mario Dorion developed a simple text file format to write lead sheets, songs with lyrics and chords, and a tool to create neatly printed lead sheets out of these text files. The tool was called *chord*, and the text files were called chord files. It soon became a popular way to write lead sheets and many users and tools adopted this format for similar purposes. For still unknown reasons people started calling the files *chordpro* files.
+
+{{< linkbutton >}}
+[Read more about its history]({{< ref "chordpro-history" >}})
+{{< /linkbutton >}}
+
+</div>
+
+<div class="column">
+
+## ChordPro.ORG
+
+In 2015 a small team of enthusiast **ChordPro** users took over the maintenance of the **ChordPro** standard from Martin and Mario and developed a new reference implementation with many new features and an easy to use graphical application.
+
+All is *Open Source* and contributions are always welcome!
+
+{{< linkbutton >}}
+[Contribute on Github]({{< param link_github >}})
+{{< /linkbutton >}}
+
+</div>
+
+</div>
+
+</div>
+
+<div id="support">
+
+# Support us
+
+<div class="row">
+
+<div class="column right-align">
+
+The **ChordPro** standard and reference implementation are free products. Free as in speech. However, web sites, storage and bandwidth cost real money. If you like **ChordPro**, please consider a small donation. We will appreciate it!
+
+</div>
+
+<div class="column left-align">
+
+[{{< awesome_icon "fa-paypal" "Paypal" >}}]({{< param link_paypal >}})
+
+[{{< awesome_icon "fa-coffee" "Buy a coffee" >}}]({{< param link_coffee >}})
+
+**Support us so we can support you!**
+
+</div>
+
+</div>
+
+</div>

--- a/docs/layouts/_default/_markup/render-image.html
+++ b/docs/layouts/_default/_markup/render-image.html
@@ -2,4 +2,4 @@
      class="img-responsive img-fluid"
      {{- with .Text }} alt="{{ . }}"{{ end -}}
      {{- with .Title}} title="{{ . }}"{{ end -}}
-/>
+>

--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -8,12 +8,12 @@
 {{- end -}}
 {{- end -}}
 {{- if $found -}}
-<a href="{{ $found.RelPermalink }}"
+<a href="{{ $found.Permalink }}"
    {{- with $found.Title}} title="{{ . }}"{{ end }}>
 {{- .Text | safeHTML }}</a>
 {{- else -}}
 <a href="{{ .Destination | safeURL }}"
    {{- with .Title}} title="{{ . }}"{{ end -}}
-   {{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>
+>
 {{- .Text | safeHTML }}</a>
 {{- end -}}

--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -4,7 +4,7 @@
 <h1>All documentation pages</h1>
 
 {{ range .Pages }}
-<p><a href="{{ .RelPermalink }}">{{ .Title | safeHTML }}</a>
+<p><a href="{{ .Permalink }}">{{ .Title | safeHTML }}</a>
 {{ end }}
 
 {{ end }}

--- a/docs/layouts/landing/baseof.html
+++ b/docs/layouts/landing/baseof.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+{{ partial "head.html" . }}
+<body>
+    <div id="wrapper">
+        <div id="content" style="max-width:800px">
+            <div id="logo">
+                <img src="{{ (resources.Get "images/chordpro-icon.png").Permalink }}" alt="ChordPro icon">
+                <p>
+                    {{ .Site.Title }}
+                </p>
+            </div>
+            <p id="subtitle">
+                {{ .Params.Subtitle }}
+            </p>
+            <p id="statement">
+                {{ .Params.Description }}
+            </p>
+            {{- block "main" . }}{{- end }}
+        </div>
+    </div>
+    <div id="footer">
+        <div class="row">
+            <div class="column left-align">
+                <p>{{ .Params.Footer1 | markdownify }}</p>
+                <p>{{ .Params.Footer2 | markdownify }}</p>
+            </div>
+            <div class="column right-align">
+                <a href="{{ .Site.Params.link_github }}">
+                    <i class="fa fa-github"></i>
+                </a>
+                <a href="{{ .Site.Params.link_paypal }}">
+                    <i class="fa fa-paypal"></i>
+                </a>
+                <a href="{{ .Site.Params.link_coffee }}">
+                    <i class="fa fa-coffee"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+</body>

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -2,24 +2,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <title>{{ if not .IsHome }}{{ with .Title }}{{ . }} | {{ end }}{{ end }}{{ .Site.Title }}</title>
+  <link rel="icon" type="image/x-icon" href="{{ (resources.Get "images/chordpro-icon.png").Permalink }}">
   <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Summary }}{{ . }}{{ else }}{{ .Site.Params.description }}{{end }}{{ end }} ">
-  <link rel="canonical" href="{{ .Permalink }}" />
-  {{ template "_internal/opengraph.html" . }}
+  {{ partial "opengraph.html" . }}
   {{ template "_internal/twitter_cards.html" . }}
   {{- with .Site.Params.keywords -}}
     <meta name="keywords" content="{{ . | safeHTMLAttr }}">
-  {{ end -}}
+  {{- end -}}
   {{ partial "head_bs4.html" . }}
   {{ partial "head_fancybox.html" . }}
-  <link rel="stylesheet" href="{{ (resources.Get "css/site.css").RelPermalink }}" />
-  <link rel="stylesheet" href="{{ (resources.Get "css/pagefind-ui.css").RelPermalink }}" />
+  <link rel="stylesheet" href="{{ (resources.Get "css/site.css").Permalink }}">
+  <link rel="stylesheet" href="{{ (resources.Get "css/pagefind-ui.css").Permalink }}">
   <!-- script src="pagefind/pagefind-ui.js"></script -->
-  <script src="{{ (resources.Get "js/pagefind-ui.js").RelPermalink }}"></script>
+  <script src="{{ (resources.Get "js/pagefind-ui.js").Permalink }}"></script>
+  {{- if eq .Type "landing" }}
+  <link rel="stylesheet" href="{{ (resources.Get "css/landing.css").Permalink }}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+  {{ end -}}
   {{- if eq hugo.Environment "stable" }}
   <style>
       a.heading-anchor {
           display: none;
       }
   </style>
-  {{- end }}
+  {{ end -}}
 </head>

--- a/docs/layouts/partials/head_bs4.html
+++ b/docs/layouts/partials/head_bs4.html
@@ -1,3 +1,3 @@
-  <link rel="stylesheet" href="{{ (resources.Get "css/bootstrap4.min.css").RelPermalink }}">
-  <script src="{{ (resources.Get "js/jquery.min.js").RelPermalink }}"></script>
-  <script src="{{ (resources.Get "js/bootstrap4.min.js").RelPermalink }}"></script>
+  <link rel="stylesheet" href="{{ (resources.Get "css/bootstrap4.min.css").Permalink }}">
+  <script src="{{ (resources.Get "js/jquery.min.js").Permalink }}"></script>
+  <script src="{{ (resources.Get "js/bootstrap4.min.js").Permalink }}"></script>

--- a/docs/layouts/partials/head_fancybox.html
+++ b/docs/layouts/partials/head_fancybox.html
@@ -1,2 +1,2 @@
-  <link rel="stylesheet" href="{{ (resources.Get "css/jquery.fancybox.min.css").RelPermalink }}">
-  <script src="{{ (resources.Get "js/jquery.fancybox.min.js").RelPermalink }}"></script>
+  <link rel="stylesheet" href="{{ (resources.Get "css/jquery.fancybox.min.css").Permalink }}">
+  <script src="{{ (resources.Get "js/jquery.fancybox.min.js").Permalink }}"></script>

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -9,7 +9,7 @@
           <ul class="navbar-nav ml-auto mt-2 mt-lg-0">
 {{- if eq hugo.Environment "stable" }}
             <li class="nav-item">
-              <a class="nav-link" href="{{ .Site.Params.stable }}">ChordPro Home</span></a>
+              <a class="nav-link" href="{{ .Site.Params.stable }}">ChordPro Home</a>
             </li>
 {{- else }}
             <li class="nav-item active">

--- a/docs/layouts/partials/opengraph.html
+++ b/docs/layouts/partials/opengraph.html
@@ -1,0 +1,5 @@
+<meta property="og:title" content="{{ .Site.Title }}">
+<meta property="og:description" content="The official site for the ChordPro file format and its reference implementation">
+<meta property="og:type"  content="website">
+<meta property="og:url" content="https://www.chordpro.org">
+<meta property="og:image" content="{{ (resources.Get "images/chordpro-icon.png").Permalink }}">

--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -3,7 +3,7 @@
 
 <div class="bg-light border-right" id="sidebar-wrapper">
     <div id="sidebar-logo">
-        <img src="{{ $logo.RelPermalink }}" />
+        <img src="{{ $logo.Permalink }}" />
         <a href="{{ ref . "Home" }}">
             ChordPro
         </a>

--- a/docs/layouts/shortcodes/asset.html
+++ b/docs/layouts/shortcodes/asset.html
@@ -1,2 +1,2 @@
 {{- $rsc := .Get 0 -}}
-{{- (resources.Get $rsc).RelPermalink -}}
+{{- (resources.Get $rsc).Permalink -}}

--- a/docs/layouts/shortcodes/awesome_icon.html
+++ b/docs/layouts/shortcodes/awesome_icon.html
@@ -1,0 +1,5 @@
+{{ if len .Params | eq 2 }}
+<i class="fa {{ .Get 0 }}"></i><span>{{ .Get 1 }}</span>
+{{ else }}
+<i class="fa {{ .Get 0 }}"></i>
+{{ end }}

--- a/docs/layouts/shortcodes/linkbutton.html
+++ b/docs/layouts/shortcodes/linkbutton.html
@@ -1,0 +1,3 @@
+<p class="link-button">
+{{ .Inner | $.Page.RenderString (dict "display" "inline") }}
+</p>

--- a/docs/layouts/shortcodes/showpage.html
+++ b/docs/layouts/shortcodes/showpage.html
@@ -6,7 +6,7 @@
 {{ range .Params }}
 {{- $large := resources.Get (printf "images/%s.png" .) -}}
 {{- $small := resources.Get (printf "images/%s-small.png" .) -}}
-  <a data-fancybox="gallery" href="{{ $large.RelPermalink }}">
-  <img src="{{ $small.RelPermalink }}"></a>
+  <a data-fancybox="gallery" href="{{ $large.Permalink }}">
+  <img src="{{ $small.Permalink }}" alt="Thumbnail"></a>
 {{ end }}
 </div>

--- a/docs/layouts/shortcodes/showpages.html
+++ b/docs/layouts/shortcodes/showpages.html
@@ -6,7 +6,7 @@
 {{ range .Params }}
 {{- $large := resources.Get (printf "images/%s.png" .) -}}
 {{- $small := resources.Get (printf "images/%s-small.png" .) -}}
-  <a data-fancybox="gallery" href="{{ $large.RelPermalink }}">
-  <img src="{{ $small.RelPermalink }}"></a>
+  <a data-fancybox="gallery" href="{{ $large.Permalink }}">
+  <img src="{{ $small.Permalink }}" alt="Thumbnail"></a>
 {{ end }}
 </div>


### PR DESCRIPTION
- All content of the page is in `docs\Landing.html`
- The external links (Github, PayPal, Coffee) are defined in the config file
- The landing page will be generated at `landing\index.html`
- This `index.html` can be moved to any other location
- I had to make all permalinks *absolute* or else `index.html` cannot be moved outside of the Hugo *public* docs
- Fixed a few html validation errors in other templates