### PR TITLE
Fix typos in docs and changes files

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,10 +82,10 @@
     - Sync config files between git and MANIFEST.
     - (Paths) Allow absolute filenames in findres.
     - (Makefile) Add Ref::Util dependency.
-    - Progress reporting. Options ``progress_callabck and -I. Also
+    - Progress reporting. Options `progress_callback` and -I. Also
       enabled with --verbose.
     - New meta: page.class (first, title, default) and page.side (left, right).
-    - Distinct page clases for even pages; filler class for alignment pages.
+    - Distinct page classes for even pages; filler class for alignment pages.
     - Add "omit" property for delegated images.
     - Allow 'mi' as short for 'min' chord quality.
     - Make properties parsing in directives more robust.

--- a/docs/content/ChordPro-Cheat_Sheet.md
+++ b/docs/content/ChordPro-Cheat_Sheet.md
@@ -101,7 +101,7 @@ Arguments to directives may be separated by a colon `:` and/or whitespace. They 
 | ... `width=` _width_                                                     |           | Width (points).                                                                                             | 5.0   |
 | ... `x=` _offset_                                                        |           | Horizontal offset (points) for [static image]({{< relref "Directives-image/#static-stationary-images" >}}). | 6.01  |
 | ... `y=` _offset_                                                        |           | Vertical offset (points) for [static image]({{< relref "Directives-image/#static-stationary-images" >}}).   | 6.01  |
-| [labelcolour]({{< relref "Directives-props_label_legacy" >}}) _colour_   |           | Margin abels colour.                                                                                        | 6.07  |
+| [labelcolour]({{< relref "Directives-props_label_legacy" >}}) _colour_   |           | Margin labels colour.                                                                                        | 6.07  |
 | [labelfont]({{< relref "Directives-props_label_legacy" >}}) _font_       |           | Margin labels font.                                                                                         | 6.07  |
 | [labelsize]({{< relref "Directives-props_label_legacy" >}}) _size_       |           | Margin labels size.                         								     | 6.07  |
 | [meta]({{< relref "Directives-meta" >}}) _item_                          |           | Metadata.                                                                                                   | 5.0   |

--- a/docs/content/ChordPro-Configuration-Create-CLI.md
+++ b/docs/content/ChordPro-Configuration-Create-CLI.md
@@ -15,7 +15,7 @@ From the command prompt, type
 
 The generated file contains most of the ChordPro configuration
 items, **all commented out**. It is easy to get started with configuring
-ChordPro by enabling and modifyng just a few items at a time.
+ChordPro by enabling and modifying just a few items at a time.
 
 For a full config, with everything set to default values, type
 

--- a/docs/content/ChordPro-Configuration-Create-GUI.md
+++ b/docs/content/ChordPro-Configuration-Create-GUI.md
@@ -23,5 +23,5 @@ A file-dialog will give you the opportunity the give your new configuration a na
 
 The configuration file contains most of the ChordPro configuration
 items, **all commented out**. It is easy to get started with configuring
-ChordPro by enabling and modifyng just a few items at a time.
+ChordPro by enabling and modifying just a few items at a time.
 

--- a/docs/content/ChordPro-GUI-Editor.md
+++ b/docs/content/ChordPro-GUI-Editor.md
@@ -22,7 +22,7 @@ Type `My First`.
 ![]({{< asset "images/chordpro-gui-editor-p3.png" >}})
 
 Press the Enter key and notice that the closing brace of the
-directice stays at the right place.
+directive stays at the right place.
 
 Add a song line: Type `[` followed by a lowercase `a`. Now type the
 closing `]`. You will see that the chord name is automatically

--- a/docs/content/ChordPro-GUI-Songbook.md
+++ b/docs/content/ChordPro-GUI-Songbook.md
@@ -35,7 +35,7 @@ button, and it will be used as cover page instead.
 
 If you created your `preview` but found some songs that are not to
 your liking; just *double-click* on the song in the *file list* and
-this will bring you the the editor where you can change the song.
+this will bring you to the editor where you can change the song.
 
 The *standard* 'Settings, preview and 'message' buttons will have an
 additional **Songbook** button to go back to your songbook again.

--- a/docs/content/ChordPro-GUI-Tasks.md
+++ b/docs/content/ChordPro-GUI-Tasks.md
@@ -14,7 +14,7 @@ previews.
 You can choose between the normal, default preview, a preview without
 chord diagrams, and a lyrics only preview for singers.
 
-Choosing `More…` gives access to more possibillities.
+Choosing `More…` gives access to more possibilities.
 
 ![]({{< asset "images/chordpro-gui-tasks-p2.png" >}})
 
@@ -44,7 +44,7 @@ A 'quick and dirty' guide to creating custom tasks. If you are
 familiar with creating folders and files you can skip most of this.
 
 1. You need to have a custom library. This can be an arbitrary,
-   preferrably empty folder. In this guide we use `ChordProLib` in the
+   preferably empty folder. In this guide we use `ChordProLib` in the
    home folder. Consult your system documentation on how to create
    this folder.
    

--- a/docs/content/ChordPro-Reference-RelNotes.md
+++ b/docs/content/ChordPro-Reference-RelNotes.md
@@ -17,9 +17,9 @@ Released: 2024-12-25
 * Sync config files between git and MANIFEST.
 * (Paths) Allow absolute filenames in findres.
 * (Makefile) Add Ref::Util dependency.
-* Progress reporting. Options ``progress_callabck and -I. Also enabled with --verbose.
+* Progress reporting. Options `progress_callback` and -I. Also enabled with --verbose.
 * New meta: page.class (first, title, default) and page.side (left, right).
-* Distinct page clases for even pages; filler class for alignment pages.
+* Distinct page classes for even pages; filler class for alignment pages.
 * Add "omit" property for delegated images.
 * Allow 'mi' as short for 'min' chord quality.
 * Make properties parsing in directives more robust.

--- a/docs/content/Directives-sortartist.md
+++ b/docs/content/Directives-sortartist.md
@@ -5,7 +5,7 @@ description: "Directives: sortartist"
 
 # Directives: sortartist
 
-This directive defines the sortname for an artist.
+This directive defines the sort name for an artist.
 
 The main purpose of the `sortartist` metadata is to provide a sort order
 for artists in the Table of Contents (ToC).

--- a/docs/content/FAQ-Sortartist.md
+++ b/docs/content/FAQ-Sortartist.md
@@ -13,7 +13,7 @@ including `sortartist` and `tag`.
 
 If you have ever copied the ChordPro configuration file to
 create your own, chances are that the metadata definitions are also there.
-Basicsally, your list of metadata directives —which does not have the
+Basically, your list of metadata directives —which does not have the
 new items— overwrites ChordPro's updated list. As a result, when you
 run ChordPro, it will not know the new added items.
 

--- a/docs/content/Install-MacOS-Native.md
+++ b/docs/content/Install-MacOS-Native.md
@@ -32,7 +32,7 @@ export PATH="/Applications/ChordPro.app/Contents/Resources/cli":$PATH
 ````
 
 The `.dmg` contains also an installation script that you can use to install 
-the application and it will add the the command line program permanently to your PATH as well.
+the application and it will add the command line program permanently to your PATH as well.
 
 Its usage is explained in the **READ ME FIRST** document as well.
 

--- a/docs/content/Using-ChordPro.md
+++ b/docs/content/Using-ChordPro.md
@@ -670,7 +670,7 @@ exits. The configuration is commented to explain its contents.
 
 The config contains most of the ChordPro configuration items, all
 commented out. It is easy to get started with configuring ChordPro
-by enabling and modifyng just a few items at a time.
+by enabling and modifying just a few items at a time.
 
 ### sysconfig
 


### PR DESCRIPTION
This should fix some minor typos in the docs and changes file.