### PR TITLE
Add Chord Provider to the links page

### DIFF
--- a/docs/content/Links.md
+++ b/docs/content/Links.md
@@ -44,3 +44,6 @@ description: "ChordPro related links"
   into a formatted section of your Office document ­ and vice versa.
   By modifying the paragraph styles you have ultimate control over how
   your song will look like.
+
+* [Chord Provider](https://github.com/Desbeers/Chord-Provider)  
+  Chord Provider is a native, open-source ChordPro file editor and viewer built specifically for macOS. The developer is a regular contributor to the official implementation.


### PR DESCRIPTION
I’m featured in a SwiftUI newsletter :-)

https://fatbobman.com/en/weekly/issue-082/

> ChordPro is a text-based markup format for aligning chords with lyrics. Nick Berendsen’s Chord Provider is a native, open-source ChordPro file editor and viewer built specifically for macOS. Written entirely in Swift 6 and SwiftUI without third-party dependencies, it’s a great reference project for macOS developers—it demonstrates best practices in managing DocumentGroup, working with CoreAudio, and using SwiftUI’s layout system. For guitar players, it’s also a clean and intuitive desktop companion.

While not a complete implementation its much better than any other application for macOS. And I contribute back...