### PR TITLE
Fix typos in pp files

### DIFF
--- a/pp/debian/README
+++ b/pp/debian/README
@@ -1,2 +1,2 @@
-These are adapted files to build a statically linkes appimage
+These are adapted files to build a statically linked appimage
 on a modern debian system.

--- a/pp/macos/README.html
+++ b/pp/macos/README.html
@@ -52,9 +52,9 @@
 
             <h3>Advanced usage</h3>
 
-            <p>The package you downloaded also contains a very powerful but maybe <em>hard-to-use</em> application that you have to run in the <code>Teminal</code>.</p>
+            <p>The package you downloaded also contains a very powerful but maybe <em>hard-to-use</em> application that you have to run in the <code>Terminal</code>.</p>
 
-            <p>Expert users can use this <code>Teminal</code> version for even more complex operations.</p>
+            <p>Expert users can use this <code>Terminal</code> version for even more complex operations.</p>
 
             <h2>It is not just drag and drop</h2>
 

--- a/pp/macos/create-dmg
+++ b/pp/macos/create-dmg
@@ -263,7 +263,7 @@ if [[ $SANDBOX_SAFE -eq 1 ]] && [[ ! -z "$DISK_IMAGE_SIZE_CUSTOM" ]] && [[ $DISK
 	DISK_IMAGE_SIZE=$DISK_IMAGE_SIZE_CUSTOM
 fi
 
-# Estimate the additional soruces size
+# Estimate the additional sources size
 if [[ -n "$ADD_FILE_SOURCES" ]]; then
 	for i in "${!ADD_FILE_SOURCES[@]}"; do
 		SOURCE_SIZE=$(get_size "${ADD_FILE_SOURCES[$i]}")


### PR DESCRIPTION
Some minor typo fixes in the pp README files of Debian and Mac.