### PR TITLE
diagrams:draw dots and fingers always

### DIFF
--- a/lib/ChordPro/Output/PDF/StringDiagram.pm
+++ b/lib/ChordPro/Output/PDF/StringDiagram.pm
@@ -274,7 +274,7 @@ method diagram_xo( $info ) {
 
     # Color of the dots and numbers.
     my $fbg = "";		# numbers
-    my $ffg = "";		# dots
+    my $ffg = $fg;		# dots
     unless ( $fsh eq "below" ) {
 	# The numbercolor property of the chordfingers is used for the
 	# color of the dot numbers.


### PR DESCRIPTION
--some pdf readers under linux like okular,
when no color has been set for dots in diagrams
they probably paint them transparent and thus are
not shown at all. That was occuring when a cho
file has set to draw its fingers "below" in the
chord diagrams. The previous implementation did
not set a default color for dots to fall back.
By setting a default color for dots to fallback
everything is shown correctly under
okular even the fingers below the diagram.

**Okular(before):**
![εικόνα](https://github.com/user-attachments/assets/8c37ab26-df11-4a21-aa3b-bed510930f48)

**Okular(after):**
![εικόνα](https://github.com/user-attachments/assets/d295cbe0-fb8f-4da2-b92d-daa989a27504)


