### PR TITLE
Update macOS packaging

### DIFF
--- a/pp/macos/Makefile
+++ b/pp/macos/Makefile
@@ -139,12 +139,10 @@ dmg1 :
 		--window-pos 200 120 \
 		--window-size 680 440 \
 		--icon-size 64 \
-		--icon "${APPDIR}" 540 75 \
+		--icon "${APPDIR}" 540 125 \
 		--hide-extension "${APPDIR}" \
-		--add-file "READ ME FIRST.html" README.html  540 175 \
+		--add-file "READ ME FIRST.html" README.html  540 250 \
 		--hide-extension "READ ME FIRST.html" \
-		--add-file "Install.zsh" Install.zsh 540 275 \
-		--hide-extension "Install.zsh" \
 		--background "${DEST}/lib/ChordPro/res/icons/chordpro-bg.png" \
 		"${DMGNAME}" "${APPDIR}"
 

--- a/pp/macos/README.html
+++ b/pp/macos/README.html
@@ -25,8 +25,9 @@
                 code {
                     font-size: 1.2em;
                 }
-                code::before, code::after {
-                    content: "“";
+                .terminal {
+                    border-left: 0.2em solid #ef6c2a;
+                    padding-left: 1em;
                 }
                 #content {
                     width: 40em;
@@ -48,13 +49,13 @@
                 <p>“A simple text format for the notation of lyrics with chords”.</p>
             </blockquote>
 
-            <p>It has a very pleasant and easy to use interface that gives you the basics of using ChordPro; both the application as well its text-format.</p>
+            <p>It has a very pleasant and easy to use interface that gives you the basics of using <strong>ChordPro</strong>; both the <em>application</em> as well its <em>text-format</em>.</p>
 
             <h3>Advanced usage</h3>
 
-            <p>The package you downloaded also contains a very powerful but maybe <em>hard-to-use</em> application that you have to run in the <code>Terminal</code>.</p>
+            <p>The package you downloaded also contains a very powerful but maybe <em>hard-to-use</em> application that you have to run in the <code>Teminal</code>.</p>
 
-            <p>Expert users can use this <code>Terminal</code> version for even more complex operations.</p>
+            <p>Expert users can use this <code>Teminal</code> version for even more complex operations.</p>
 
             <h2>It is not just drag and drop</h2>
 
@@ -70,47 +71,54 @@
 
             <p>Your download contains an <em>almost</em> ready to go <strong>ChordPro</strong>; except that the application is only ad-hoc signed by us and not by an approved Apple Developer with a valid certificate. So, the security system on your Mac will give an error when you double-click the application. You have met the <em>Gatekeeper</em>. Depending of the version of macOS you have a different message and have to do different additional handlings to open <strong>ChordPro</strong>.</p>
 
-            <p>The message will be more or less like this:</p>
+            <ol>
+                <li>Drag the application to your <code>Applications</code> folder.
+                <li>Open the application by <em>double-clicking</em> on it.
+            </ol>
+
+            <p>A prompt saying '“<strong>ChordPro</strong>“ Not Opened' will appear.</p>
+
+            <p>The message will be more or less like this, depending on your macOS version:</p>
 
             <blockquote>
                 <p>Apple could not verify “ChordPro.app“ is free of malware that may harm your Mac or compromise your privacy.</p>
             </blockquote>
 
+            <p><em>There is a small 'question mark' button at the right top of the dialog that opens the 'Mac User Guide' with more information.</em></p>
+
             <p>On macOS versions before 15 (Sequoia) it was common practice to <code>right-click</code> the application and choose <code>Open</code> from the menu. That trick will bypass the gatekeeper and let you open the application.</p>
 
-            <p>Unfortunately, that does not work anymore on Sequoia and you have to go trough System Settings:</p>
+            <p>Unfortunately, that does not work anymore on Sequoia and you have to go trough <code>System Settings</code>:</p>
 
-            <ol>
-                <li>Try to open the application. A prompt saying “ChordPro.app“ Not Opened' may appear.</li>
-                <li>Go to <code>System Settings -&gt; Privacy &amp; Security</code>. Scroll down to find <em>ChordPro</em>, and an option to &quot;Open Anyway&quot;.</li>
+            <ol start="3">
+                <li>Go to <code>System Settings -&gt; Privacy &amp; Security</code>.</li>
+                <li>Scroll down to find <strong>ChordPro</strong>, and an option to &quot;Open Anyway&quot;.</li>
                 <li>Choose &quot;Open Anyway&quot;.</li>
                 <li>Authenticate as an administrator.</li>
-                <li><em>ChordPro</em> will now open.</li>
+                <li><strong>ChordPro</strong> will now open.</li>
             </ol>
 
-            <h2>Install with the Terminal</h2>
+            <p><strong>ChordPro</strong> is saved as an exception to your security settings and you can open it in the future by double-clicking it, just as you can with any other application.</p>
 
-            <p>Your download also contains an <code>Install</code> script that can do this for you. Same as with the <code>ChordPro.app</code>, you can not just double click to run the script. You have to run it manually in the Terminal yourself:</p>
+            <h2>The Terminal Application</h2>
 
-            <blockquote>
-                <p>Open the <strong>Terminal</strong> application in <code>Applications/Utilities</code> and just <em>drag and drop</em> the <code>Install</code> script into its window.</p>
-            </blockquote>
+            <p>The <em>Terminal</em> application, simply called <code>chordpro</code> is part of the package.</p>
 
-            <p>It will do the following:</p>
+            <p>To <em>temporarily</em> add the command line program to the system path issue the following command in the <em>Terminal</em> window:</p>
 
-            <ul>
-                <li>Copy <em>ChordPro</em> to your applications folder</li>
-                <li>Move <em>ChordPro</em> out of quarantine so the Gatekeeper will let you start the application with just a double-click.</li>
-                <li>Add the <em>ChordPro</em> command-line command to your Terminal $PATH</li>
-            </ul>
+            <div class="terminal">
+                <code>export PATH="/Applications/ChordPro.app/Contents/Resources/cli":$PATH
+                </code>
+            </div>
 
-            <p><strong>It will not do anything without your permission but by providing your administration password, you will bypass all Apple’s security measurements.</strong></p>
+            <p>To add a command line application <em>permanently</em> to your system path, there are simply no <em>simple</em> instructions. It depends on your version of macOS.
+            Please use your favourite search engine.</p>
 
             <h2>Enjoy!</h2>
 
-            <p>We hope you appreciate our best efforts.</p>
+            <p>We hope you appreciate our best efforts to bring <strong>ChordPro</strong> to macOS.</p>
 
-            <p>The Mac is a beautiful platform for its users.</p>
+            <p>The Mac is a beautiful platform for its users. However, not so much for its Mac developers nowadays. We do our best.</p>
 
             <p><strong>Are you a macOS developer with an Developer Account? Please help us to provide a signed package to improve the user experience.</strong></p>
 


### PR DESCRIPTION
- Remove install script from the package in the MaleFile

While it still works on older macOS versions than macOS Sequoia 15.4, I removed it to avoid confusion and just looking forward

- Update README
- Kept my personal opinion to the minimum ;-)

The `Install.zsh` itself is not removed because I’m proud of it.