### PR TITLE
always draw fingers text when acceptable

### DIFF
--- a/lib/ChordPro/Output/PDF/StringDiagram.pm
+++ b/lib/ChordPro/Output/PDF/StringDiagram.pm
@@ -384,9 +384,9 @@ method diagram_xo( $info ) {
 	    }
 
 	    unless ( $did++ ) {
-                if ( $fsh eq "below" ) {
-                    $size *= 1.4;
-                }
+		if ( $fsh eq "below" ) {
+		    $size *= 1.4;
+		}
 		$xo->fill_color($fbg);
 		$xo->textstart;
 		$xo->font( $font, $size );


### PR DESCRIPTION
- Introduced from #584
the user now is able to define font, color and numbercolor for
fingers text in the diagrams. The new introduced
code there were cases that the fingers text
was not drawn at even though it should. For
example when the user has set "below" finger text
but all the other values were default; in that
case the finger text color was set to "white"
and was not shown to the user.

- During the code analysis a variable "$asc" was identified
that was never used so it was deleted.

- The fingers text increase by 1.5 only for the "below" case
is not necessary any more and was deleted.

- The new warning message was set to be activated
only when debugging the diagrams.

**Use Cases / Testing:**
![εικόνα](https://github.com/user-attachments/assets/ca11bd4f-6b17-4742-91cf-6cd05866e241)
