### PR TITLE
Fix invalid PDF date string generation

### DIFF
--- a/lib/ChordPro/Output/PDF/Writer.pm
+++ b/lib/ChordPro/Output/PDF/Writer.pm
@@ -109,20 +109,17 @@ sub pdf_date {
     my ( $t ) = @_;
     $t ||= $regtest ? $faketime : time;
 
-    use POSIX qw( strftime );
-    my $r;
-    if ( is_msw && $] < 5.040 ) {
-	# Work around a bug in older strftime.
-	my @tm = gmtime($t);
-	$r = sprintf( "%04d%02d%02d%02d%02d%02d+00'00'",
-		      1900+$tm[5], @tm[4,3,2,1,0] );
-    }
-    else {
-	$r = strftime( "%Y%m%d%H%M%S%z", localtime($t) );
-	# Don't use s///r to keep PERL_MIN_VERSION low.
-	$r =~ s/(..)$/'$1'/;	# +0100 -> +01'00'
-    }
-    $r;
+    my @tm = gmtime($t);
+
+    return sprintf(
+        "%04d%02d%02d%02d%02d%02d+00'00'",
+        1900 + $tm[5],
+        $tm[4] + 1,
+        $tm[3],
+        $tm[2],
+        $tm[1],
+        $tm[0],
+    );
 }
 
 sub wrap {


### PR DESCRIPTION
Hello,

On January 1st, 2026, ChordPro did not allow me to generate a PDF for a song.
The error message was:

`Error: Invalid date string: D:20260003005605+00'00'
at lib/ChordPro/Output/PDF/Writer.pm line 93
Error: Fatal problems found.
`

I investigated the issue and found that the PDF date string being generated was invalid.

I modified the code to generate a PDF-compliant date format.

I tested the change locally and PDF generation now works correctly.

I am not a Perl expert, but I researched the required PDF date format and made the necessary changes to fix the issue.

Thank you for your time and for maintaining ChordPro.

Kind regards,
Ruben Mora