### PR TITLE
Add BandBinder to Links page

### DIFF
--- a/docs/content/Links.md
+++ b/docs/content/Links.md
@@ -16,6 +16,13 @@ description: "ChordPro related links"
   Searchable web site with a vast collection of ChordPro notated
   songs.
 
+* [BandBinder](https://bandbinder.app)  
+  BandBinder is for bands or solo musicians to keep charts, setlists and rehearsal notes.
+  It uses ChordPro format to render chords inline with lyrics and performance notes.
+  It can transpose on the fly and help you learn chord shapes for 7 instruments.
+  BandBinder publishes a ChordPro authoring guide, directive reference and examples at
+  [docs.bandbinder.app/chordpro](https://docs.bandbinder.app/chordpro/).
+
 * [Songsheet Generator](http://tenbyten.com/software/songsgen/index.php)  
   Songsheet Generator is an application which prints songsheets
   and songbooks for home, small group, or large group 


### PR DESCRIPTION
Add **[BandBinder](https://bandbinder.app/)** to Links page. If this entry is too long or you'd rather word it differently, let me know and I'll amend it.

I'm the creator of BandBinder. It reads and writes ChordPro natively across several platforms (Windows, macOS, Linux, Android and iOS). I believe it's worth listing next to other ChordPro implementations.

I've also published a ChordPro authoring guide, a directive-to-feature map and a set of worked examples at https://docs.bandbinder.app/chordpro/ 

I'm trying to create more awareness of ChordPro standard in general by cross-linking from BandBinder to your official ChordPro.org site. I'm creating help content to make it easier for BandBinder users to author charts in ChordPro format. And to build on synergy between BandBinder + ChordPro. The app even has intellisense for ChordPro directives and Chords.

<img width="378" height="195" alt="image" src="https://github.com/user-attachments/assets/8b4f6625-c81c-43c6-9092-81fc2958db5e" />
<img width="433" height="256" alt="image" src="https://github.com/user-attachments/assets/5d0da125-4d9d-446c-9d5e-9a7cdcd324a9" />

