### PR TITLE
Update config

### DIFF
--- a/lib/ChordPro/res/config/config.schema
+++ b/lib/ChordPro/res/config/config.schema
@@ -574,12 +574,6 @@
         "replace": {
           "type": "string",
           "description": "A string that replaces occurrences of `target`/`pattern`."
-        },
-        "flags": {
-          "type": "string",
-          "description": "Regular expression flags.",
-          "default": "g",
-          "examples": ["gi"]
         }
       },
       "oneOf": [
@@ -590,6 +584,12 @@
               "type": "string",
               "description": "A regular expression to search for and replace.",
               "format": "regex"
+            },
+            "flags": {
+              "type": "string",
+              "description": "Regular expression flags.",
+              "default": "g",
+              "examples": ["gi"]
             }
           }
         },

--- a/lib/ChordPro/res/config/config.schema
+++ b/lib/ChordPro/res/config/config.schema
@@ -618,6 +618,14 @@
           "type": "object",
           "description": "Settings for the parser/preprocessor.\nFor selected lines, you can specify a series of \n{ \"target\" : \"xxx\", \"replace\" : \"yyy\" }\nEvery occurrence of \"xxx\" will be replaced by \"yyy\".\nUse \"pattern\" instead of \"target\" for regular expression replacement.\nUse wisely.",
           "additionalProperties": false,
+          "patternProperties": {
+            "^env-": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/parserPreprocessingElement"
+              }
+            }
+          },
           "properties": {
             "all": {
               "type": "array",

--- a/lib/ChordPro/res/config/config.schema
+++ b/lib/ChordPro/res/config/config.schema
@@ -629,7 +629,6 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "additionalProperties": false,
                 "anyOf": [
                   {
                     "$ref": "#/definitions/parserPreprocessingElement"

--- a/lib/ChordPro/res/config/config.schema
+++ b/lib/ChordPro/res/config/config.schema
@@ -569,7 +569,6 @@
     },
     "parserPreprocessingElement": {
       "type": "object",
-      "additionalProperties": false,
       "required": ["replace"],
       "properties": {
         "replace": {

--- a/lib/ChordPro/res/config/config.schema
+++ b/lib/ChordPro/res/config/config.schema
@@ -629,7 +629,7 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "anyOf": [
+                "allOf": [
                   {
                     "$ref": "#/definitions/parserPreprocessingElement"
                   },

--- a/lib/ChordPro/res/config/config.schema
+++ b/lib/ChordPro/res/config/config.schema
@@ -579,7 +579,8 @@
         "flags": {
           "type": "string",
           "description": "Regular expression flags.",
-          "examples": ["g", "gi"]
+          "default": "g",
+          "examples": ["gi"]
         }
       },
       "oneOf": [


### PR DESCRIPTION
- In `#/definitions/parserPreprocessingElement`, moved `"g"` from `examples` to separate `default`. In VS Code, this is nearly identical, showing both `default` and `examples` as suggested values, but now `"g"` will be labeled in the helper popup as "Default value".
- Removed `"additionalProperties": false` from `#/definitions/parserPreprocessingElement`, as it caused a validation error once `pattern` or `target` would get added to a config file.
- Removed `"additionalProperties": false` from `parser.preprocess.directive`, as it caused validation error due to not working well with `allOf`/`anyOf`.
- Changed `anyOf` to `allOf` in `parser.preprocess.directive`, as `anyOf` didn't enforce the required properties in `#/definitions/parserPreprocessingElement`. Previously, this would allow `select` to be present without any of the properties from `parserPreprocessingElement`. Using `allOf` enforces the required properties from `parserPreprocessingElement`.
- Moved `#/definitions/parserPreprocessingElement`'s `flags` property to be in the `oneOf` clause with `pattern`, as it wouldn't be used with `target`, as it's not a regular expression.
- Added `patternProperties` to `parser.preprocess` to add support of section-specific (environment-specific) preprocessing.

Mention: #520 